### PR TITLE
When a subordinate step fails, raise the exception of that step rather than a generic 'Subordinate steps failed for this step.' message.

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -298,7 +298,8 @@ class Step(object):
             def elsewhere(step):
                 # actual step behavior, maybe.
 
-        This will raise error (thus halting execution of the step) if a subordinate step fails.
+        This will raise the error of the first failing step (thus halting 
+        execution of the step) if a subordinate step fails.
 
         """
         lines = string.split('\n')
@@ -312,7 +313,7 @@ class Step(object):
         else:
             self.passed = False
             self.failed = True
-            assert not steps_failed, "Subordinate steps failed for this step."
+            assert not steps_failed, steps_failed[0].why.exception
 
     def run(self, ignore_case):
         """Runs a step, trying to resolve it on available step


### PR DESCRIPTION
Whenever a subordinate step fails, I have to debug the code to understand where and why that error took place. This is because the console only reports a generic 'Subordinate steps failed for this step.' message.

With this commit, I change this behavior to raise instead the exception of the first failing step, so that can be corrected more quickly.
