### PR TITLE
Add multiline string support

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -13,6 +13,7 @@ Lettuce documentation contents
    intro/wtf
    tutorial/simple
    tutorial/tables
+   tutorial/multiline
    tutorial/scenario-outlines
    tutorial/steps-from-step-definitions
    reference/features

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,6 +104,7 @@ walkthrough
 
     * :ref:`write your first feature <tutorial-simple>`
     * :ref:`handling data with tables <tutorial-tables>`
+    * :ref:`multi-line strings <tutorial-multiline>`
     * :ref:`don't repeat yourself, meet scenario outlines <tutorial-scenario-outlines>`
     * :ref:`clean up your spec definitions, calling one step from another <tutorial-steps-from-step-definitions>`
 

--- a/docs/tutorial/multiline.rst
+++ b/docs/tutorial/multiline.rst
@@ -1,0 +1,117 @@
+.. _tutorial-multiline:
+
+multi-line strings
+===========================
+
+Now imagine you are writing an application which manipulates
+strings. When writing the tests, you may find yourself wanting to put
+multi-line strings in your steps.
+
+Multi-line strings will do the trick
+
+.. highlight:: ruby
+
+::
+
+   Feature: Split a string into multiple lines on spaces
+     In order to make strings more readable
+     As a user
+     I want to have words split into their own lines
+
+     Scenario: Split small-ish string
+       Given I have the string "one two three four five"
+       When I ask to have the string split into lines
+       Then I should see the following:
+         """
+         one
+         two
+         three
+         four
+         five
+         """
+
+A line with nothing but three quotes (""") is used to indicate the
+beginning and the end of a multi-line string.
+
+Now, let's define a step that knows how to use this.
+
+.. highlight:: python
+
+::
+
+      from lettuce import step
+
+      @step('I should see the following:')
+      def i_should_see_the_following(step):
+          assert step.multiline == """one
+      two
+      three
+      four
+      five"""
+
+
+Nice and straightforward.
+
+Notice that leading spaces are stripped, and there's not a newline at
+the beginning or end. This is due to the way that the parser strips
+blank lines and leading and trailing whitespace.
+
+If you need blank lines leading or trailing whitespace, you can
+include lines which start and/or end with double quote, and they will
+be concatenated with the other multiline lines, with the quotes
+stripped off and their whitespace preserved.
+
+For example
+
+.. highlight:: ruby
+
+::
+
+   Feature: Split a string into multiple lines on spaces
+     In order to make strings more readable
+     As a user
+     I want to have words split into their own lines
+
+     Scenario: Split small-ish string
+       Given I have the string "one two three four five"
+       When I ask to have the string split into lines
+       Then I should see the following:
+         """
+        " one
+        " two  "
+        "  three   "
+        "   four    "
+        "    five     "
+        "
+         """
+
+Which we can verify like so:
+
+.. highlight:: python
+
+::
+
+      from lettuce import step
+
+      @step('I should see the following:')
+      def i_should_see_the_following(step):
+          assert step.multiline == '\n'.append([
+          ' one',
+          '  two  ',
+          '   three   ',
+          '    four    ',
+          '     five     ',
+          ''])
+
+
+
+Admittedly, this is a hack, but there's no clean way to preserve
+whitespace in only one section of a feature definition in the current
+parser implementation.
+
+Note that the first line doesn't have any whitespace at the end, and
+thus doesn't need to have a quote at the end of it.
+
+Also note that if you want a double quote at the beginning of a line
+in your string, you'll have to start your line with two double quotes,
+since the first one will be stripped off.

--- a/lettuce/strings.py
+++ b/lettuce/strings.py
@@ -130,3 +130,17 @@ def parse_hashes(lines):
             hashes.append(dict(zip(keys, values)))
 
     return keys, hashes
+
+def parse_multiline(lines):
+    multilines = []
+    in_multiline = False
+    for line in lines:
+        if line == '"""':
+            in_multiline = not in_multiline
+        elif in_multiline:
+            if line.startswith('"'):
+                line = line[1:]
+            if line.endswith('"'):
+                line = line[:-1]
+            multilines.append(line)
+    return u'\n'.join(multilines)


### PR DESCRIPTION
I've implemented, written tests for, and written documentation for multiline strings.

Ideally, indentation would simply be preserved if the lines inside the multi-line string were indented past the indentation of the """, but since the lines are stripped far before getting to that point, I extended the cucumber behavior a smidgen by allowing a single double-quote at the beginning and/or end of a line to be used to preserve leading/closing whitespace and to allow for blank lines (a description of this behavior is in the documentation, as well).

Related issue: https://github.com/gabrielfalcao/lettuce/issues#issue/99
