### PR TITLE
Windows terminal colored output fix

### DIFF
--- a/lettuce/plugins/colored_shell_output.py
+++ b/lettuce/plugins/colored_shell_output.py
@@ -17,9 +17,8 @@
 import os
 import re
 import sys
-import fcntl
+import platform
 import struct
-import termios
 
 from lettuce import strings
 from lettuce import core
@@ -27,6 +26,37 @@ from lettuce.terrain import after
 from lettuce.terrain import before
 
 def get_terminal_size():
+    if platform.system() == "Windows":
+        return get_terminal_size_win()
+    else:    
+        return get_terminal_size_unix()
+
+def get_terminal_size_win():
+    #Windows specific imports
+    from ctypes import windll, create_string_buffer
+    # stdin handle is -10
+    # stdout handle is -11
+    # stderr handle is -12
+    
+    h = windll.kernel32.GetStdHandle(-12)
+    csbi = create_string_buffer(22)
+    res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
+    
+    if res:
+        import struct
+        (bufx, bufy, curx, cury, wattr,
+         left, top, right, bottom, maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+        sizex = right - left + 1
+        sizey = bottom - top + 1
+    else:
+        sizex, sizey = 80, 25 # can't determine actual size - return default values
+    
+    return sizex, sizey
+
+
+def get_terminal_size_unix():
+    # Unix/Posix specific imports 
+    import fcntl, termios
     def ioctl_GWINSZ(fd):
         try:
             cr = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ,
@@ -49,6 +79,7 @@ def get_terminal_size():
             cr = (25, 80)
 
     return int(cr[1]), int(cr[0])
+
 
 def wrt(what):
     sys.stdout.write(what.encode('utf-8'))


### PR DESCRIPTION
This it to fix the bug when lettuce blown out on Windows machine:

---

Traceback (most recent call last):
File "lettuce-script.py", line 8, in <module>
load_entry_point('lettuce==0.1.19', 'console_scripts', 'lettuce')()
File "C:\Python\Python27\lib\site-packages\lettuce-0.1.19-py2.7.egg\lettuce\commands.py", line 51, in main
runner = lettuce.Runner(base_path, scenarios=options.scenarios, verbosity=options.verbosity)
File "C:\Python\Python27\lib\site-packages\lettuce-0.1.19-py2.7.egg\lettuce__init__.py", line 87, in **init**
from lettuce.plugins import colored_shell_output as output
File "C:\Python\Python27\lib\site-packages\lettuce-0.1.19-py2.7.egg\lettuce\plugins\colored_shell_output.py", line 20, in <module>

import fcntl
ImportError: No module named fcntl

---

more details at http://disq.us/15cmo6
