### PR TITLE
Immediately stop on an invalid step regex.

### DIFF
--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -34,6 +34,7 @@ from lettuce.decorators import step
 from lettuce.registry import call_hook
 from lettuce.registry import STEP_REGISTRY
 from lettuce.registry import CALLBACK_REGISTRY
+from lettuce.exceptions import StepLoadingError
 from lettuce.plugins import xunit_output
 
 from lettuce import exceptions
@@ -100,7 +101,11 @@ class Runner(object):
         features under `base_path` specified on constructor
         """
         started_at = datetime.now()
-        self.loader.find_and_load_step_definitions()
+        try:
+            self.loader.find_and_load_step_definitions()
+        except StepLoadingError, e:
+            print "Error loading step definitions:\n", e
+            return
 
         call_hook('before', 'all')
 

--- a/lettuce/decorators.py
+++ b/lettuce/decorators.py
@@ -14,8 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import re
 from lettuce.core import STEP_REGISTRY
+from lettuce.exceptions import StepLoadingError
 
 def step(regex):
     """Decorates a function, so that it will become a new step
@@ -35,6 +36,13 @@ def step(regex):
     Notice that all step definitions take a step object as argument.
     """
     def wrap(func):
+        try:
+            re.compile(regex)
+        except re.error, e:
+            raise StepLoadingError("Error when trying to compile:\n"
+                                   "  regex: %r\n"
+                                   "  for function: %s\n"
+                                   "  error: %s" % (regex, func, e))
         STEP_REGISTRY[regex] = func
 
     return wrap

--- a/lettuce/exceptions.py
+++ b/lettuce/exceptions.py
@@ -44,3 +44,7 @@ class LettuceSyntaxError(SyntaxError):
         self.filename = filename
         self.msg = "Syntax error at: %s\n%s\n" % (filename, string)
 
+
+class StepLoadingError(Exception):
+    """Raised when a step cannot be loaded."""
+    pass


### PR DESCRIPTION
If an invalid regex is stored in the STEP_REGISTRY,
depending on the iteration order of the registry,
when the regex is searched (regexes are not stored
compiled) it generates an error or ends up with
a step getting skipped.

The behavior now is to stop as soon as a regex
that won't compile is found.
