### PR TITLE
Fix for Django integration test

### DIFF
--- a/tests/integration/django/grocery/features/ability_to_fetch_admin_media.feature
+++ b/tests/integration/django/grocery/features/ability_to_fetch_admin_media.feature
@@ -28,4 +28,4 @@ Feature: fetch admin media from lettuce + django builtin server
       | /media/js/timeparse.js             |
       | /media/js/urlify.js                |
     When all the responses have status code 200
-    Then all the responses have mime type "application/javascript"
+    Then all the responses have mime type "text/javascript"


### PR DESCRIPTION
The test was checking for application/javascript MIME type, whereas the Django
test server was serving it as text/javascript. I'm not sure if that is affected by Django
version. Perhaps a more promiscuous MIME type check is needed. I installed Django via the requirements.txt and pip installed 1.3.0.
