### PR TITLE
Better traceback when failing out of behave_as

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -363,7 +363,7 @@ class Step(object):
         else:
             self.passed = False
             self.failed = True
-            assert not steps_failed, steps_failed[0].why.exception
+            assert not steps_failed, steps_failed[0].why.traceback
 
     def run(self, ignore_case):
         """Runs a step, trying to resolve it on available step


### PR DESCRIPTION
When failing out of a behave_as, emit the failing traceback to help clarify where things went wrong.
