### PR TITLE
Please accept smal fix related to skipped steps to xunit output plugin

### DIFF
--- a/lettuce/plugins/xunit_output.py
+++ b/lettuce/plugins/xunit_output.py
@@ -47,6 +47,10 @@ def enable(filename=None):
         tc.setAttribute("classname", classname)
         tc.setAttribute("name", step.sentence)
         tc.setAttribute("time", str(total_seconds((datetime.now() - step.started))))
+        
+        if not step.ran:
+            skip=doc.createElement("skipped")
+            tc.appendChild(skip)
 
         if step.failed:
             cdata = doc.createCDATASection(step.why.traceback)


### PR DESCRIPTION
 Now xunit output reports steps that are not failed as passed, but in fact step may be skipped. So steps are reported as passed.
 Unfortunatley there is no real standard for xml schema of Junit/Xunit format, so I used version, that is understood by current version of Jenkins (with separate element). Output is tested and works with jenkins built-in parser.
