### PR TITLE
Make proposed step sentence a less greedy regular expression

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -179,6 +179,8 @@ class Step(object):
     passed = None
     failed = None
     related_outline = None
+    DOUBLE_QUOTED_ARGUMENT = re.compile(r'("[^"]+")')
+    SINGLE_QUOTED_ARGUMENT = re.compile(r"('[^']+')")
 
     def __init__(self, sentence, remaining_lines, line=None, filename=None):
         self.sentence = sentence
@@ -189,35 +191,26 @@ class Step(object):
         self.keys = tuple(keys)
         self.hashes = HashList(self, hashes)
         self.described_at = StepDescription(line, filename)
-
         self.proposed_method_name, self.proposed_sentence = self.propose_definition()
 
     def propose_definition(self):
-
         sentence = unicode(self.original_sentence)
         method_name = sentence
 
         groups = [
-            ('"', re.compile(r'("[^"]+")')), # double quotes
-            ("'", re.compile(r"('[^']+')")), # single quotes
+            ('"', Step.DOUBLE_QUOTED_ARGUMENT, u'"([^"]+)"'),
+            ("'", Step.SINGLE_QUOTED_ARGUMENT, u"\\'([^\\']+)\\'"),
         ]
 
         attribute_names = []
-        for char, group in groups:
+        for char, group, template in groups:
             match_groups = group.search(self.original_sentence)
-
             if match_groups:
-
                 for index, match in enumerate(group.findall(sentence)):
-                    if char == "'":
-                        char = re.escape(char)
-
-                    sentence = sentence.replace(match, u'%s(.*)%s' % (char, char))
+                    sentence = sentence.replace(match, template)
                     group_name = u"group%d" % (index + 1)
                     method_name = method_name.replace(match, group_name)
                     attribute_names.append(group_name)
-
-
 
         method_name = unicodedata.normalize('NFKD', method_name) \
                       .encode('ascii', 'ignore')

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -718,7 +718,7 @@ def test_output_snippets_with_groups_within_double_quotes_colorless():
         u"# -*- coding: utf-8 -*-\n"
         u'from lettuce import step\n'
         u'\n'
-        u'@step(u\'Given I have "(.*)" and "(.*)"\')\n'
+        u'@step(u\'Given I have "([^\"]+)" and "([^\"]+)"\')\n'
         u'def given_i_have_group1_and_group2(step, group1, group2):\n'
         u'    assert False, \'This step must be implemented\'\n'
     )
@@ -746,7 +746,7 @@ def test_output_snippets_with_groups_within_double_quotes_colorful():
         u"# -*- coding: utf-8 -*-\n"
         u'from lettuce import step\n'
         u'\n'
-        u'@step(u\'Given I have "(.*)" and "(.*)"\')\n'
+        u'@step(u\'Given I have "([^"]+)" and "([^"]+)"\')\n'
         u'def given_i_have_group1_and_group2(step, group1, group2):\n'
         u'    assert False, \'This step must be implemented\'\033[0m\n'
     )
@@ -775,7 +775,7 @@ def test_output_snippets_with_groups_within_single_quotes_colorless():
         u"# -*- coding: utf-8 -*-\n"
         u'from lettuce import step\n'
         u'\n'
-        u'@step(u\'Given I have \\\'(.*)\\\' and \\\'(.*)\\\'\')\n'
+        u'@step(u\'Given I have \\\'([^\\\']+)\\\' and \\\'([^\\\']+)\\\'\')\n'
         u'def given_i_have_group1_and_group2(step, group1, group2):\n'
         u'    assert False, \'This step must be implemented\'\n'
     )
@@ -803,7 +803,7 @@ def test_output_snippets_with_groups_within_single_quotes_colorful():
         u"# -*- coding: utf-8 -*-\n"
         u'from lettuce import step\n'
         u'\n'
-        u'@step(u\'Given I have \\\'(.*)\\\' and \\\'(.*)\\\'\')\n'
+        u'@step(u\'Given I have \\\'([^\\\']+)\\\' and \\\'([^\\\']+)\\\'\')\n'
         u'def given_i_have_group1_and_group2(step, group1, group2):\n'
         u'    assert False, \'This step must be implemented\'\033[0m\n'
     )
@@ -832,7 +832,7 @@ def test_output_snippets_with_groups_within_redundant_quotes():
         u"# -*- coding: utf-8 -*-\n"
         u'from lettuce import step\n'
         u'\n'
-        u'@step(u\'Given I have "(.*)" and "(.*)"\')\n'
+        u'@step(u\'Given I have "([^"]+)" and "([^"]+)"\')\n'
         u'def given_i_have_group1_and_group2(step, group1, group2):\n'
         u'    assert False, \'This step must be implemented\'\n'
     )
@@ -868,7 +868,7 @@ def test_output_snippets_with_normalized_unicode_names():
         u"@step(u'Dado que eu tenho palavrões e outras situações')\n"
         u"def dado_que_eu_tenho_palavroes_e_outras_situacoes(step):\n"
         u"    assert False, 'This step must be implemented'\n"
-        u"@step(u'E várias palavras acentuadas são úteis, tais como: \"(.*)\"')\n"
+        u"@step(u'E várias palavras acentuadas são úteis, tais como: \"([^\"]+)\"')\n"
         u"def e_varias_palavras_acentuadas_sao_uteis_tais_como_group1(step, group1):\n"
         u"    assert False, 'This step must be implemented'\n"
         u"@step(u'Então eu fico felizão')\n"
@@ -1061,7 +1061,7 @@ def test_run_only_features_tagged():
     "Test that only features (and their scenarios) are run if tags match"
 
     world.colours = []
-    
+
     @step('Running "(.*)" scenario')
     def keep_colours(step, colour):
         world.colours.append(colour)


### PR DESCRIPTION
I found the default proposed step regex is greedy and is problematic when you have multiple steps that are subsets of one another. I thought it would be useful to have the proposed regex only match until the next surrounding group character. 

This saves a little editing when proposed steps are copied into the editor. Might be fractionally faster since the regex is only compiled one.
