### PR TITLE
Return the function being decorated from the before/after decorators.

### DIFF
--- a/lettuce/terrain.py
+++ b/lettuce/terrain.py
@@ -45,6 +45,7 @@ class Main(object):
     def _add_method(cls, name, where, when):
         def method(self, fn):
             CALLBACK_REGISTRY.append_to(where, when.format(self.name), fn)
+            return fn
         method.__name__ = method.fn_name = name
         setattr(cls, name, method)
 


### PR DESCRIPTION
When a function is decorated with the before/after decorators, the function effectively disappears from the namespace as Main._add_method's method function isn't returning the decorated function.  This commit fixes this issue.
