### PR TITLE
Step registry contains duplicate entries

### DIFF
--- a/lettuce/registry.py
+++ b/lettuce/registry.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys
+import os
 import threading
 import traceback
 
@@ -23,7 +24,7 @@ world._set = False
 
 
 def _function_matches(one, other):
-    return (one.func_code.co_filename == other.func_code.co_filename and
+    return (os.path.abspath(one.func_code.co_filename) == os.path.abspath(other.func_code.co_filename) and
             one.func_code.co_firstlineno == other.func_code.co_firstlineno)
 
 


### PR DESCRIPTION
Sometimes one.func_code.co_filename contains relative paths. E.g. 
/home/atizo/terrain.py
/home/atizo/../atizo/terrain.py
Therefore the step registry contains duplicate entries
