### PR TITLE
Should exit with status 0 when test pass.

### DIFF
--- a/lettuce/lettuce_cli.py
+++ b/lettuce/lettuce_cli.py
@@ -71,6 +71,7 @@ def main(args=sys.argv[1:]):
     result = runner.run()
     if not result or result.steps != result.steps_passed:
         raise SystemExit(1)
+    raise SystemExit(0)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
without this line, lettuce will not exit when test pass.
this is a terrible thing in automatically test.
I haven't found a proper way to test it with lettuce's tests.

You can test like this:(put these two lines in test.sh, and run it. )
lettuce path1
lettuce path2

if test in path1 pass, then "lettuce path2" will not run.
