### PR TITLE
Importing colorama for winodws if it exists

### DIFF
--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -39,6 +39,13 @@ from lettuce.plugins import xunit_output
 
 from lettuce import exceptions
 
+if os.name == 'nt':
+    try:
+        from colorama import init
+        init()
+    except ImportError:
+        pass
+
 __all__ = [
     'after',
     'before',


### PR DESCRIPTION
Currently the colored output does not work on windows.
I have edited the `__init__.py` file to import and initialize colorama if python is running on windows and the library exists.
