### PR TITLE
Reraise the exception rather than raising a copy

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -119,7 +119,7 @@ class StepDefinition(object):
         except Exception, e:
             self.step.failed = True
             self.step.why = ReasonToFail(e)
-            raise e
+            raise
 
         return ret
 


### PR DESCRIPTION
If you use traceback.format_exc somewhere in lettuce - I'm using it in a @after.step - the exceptions are not too helpful. It seems it's because this line raises a new exception rather than just reraising the existing exception. Here's a before and after comparison from this small change.

Before:

```
File "/Library/Python/2.7/site-packages/lettuce-0.1.34-py2.7.egg/lettuce/core.py", line 414, in run_all
step.run(ignore_case)
File "/Library/Python/2.7/site-packages/lettuce-0.1.34-py2.7.egg/lettuce/core.py", line 380, in run
step_definition(*groups)
File "/Library/Python/2.7/site-packages/lettuce-0.1.34-py2.7.egg/lettuce/core.py", line 122, in __call__
raise e
AssertionError
```

After:

```
File "/Library/Python/2.7/site-packages/lettuce-0.1.34-py2.7.egg/lettuce/core.py", line 414, in run_all
step.run(ignore_case)
File "/Library/Python/2.7/site-packages/lettuce-0.1.34-py2.7.egg/lettuce/core.py", line 380, in run
step_definition(*groups)
File "/Library/Python/2.7/site-packages/lettuce-0.1.34-py2.7.egg/lettuce/core.py", line 117, in __call__
ret = self.function(self.step, *args, **kw)
File "/Users/jtatum/project/features/steps.py", line 9, in this_will_fail
assert False
AssertionError
```
