### PR TITLE
os.getenv does not raise an exception when the value is not found. This ...

### DIFF
--- a/lettuce/terminal.py
+++ b/lettuce/terminal.py
@@ -74,9 +74,6 @@ def get_terminal_size_unix():
         except:
             pass
     if not cr:
-        try:
-            cr = (os.getenv('LINES'), os.getenv('COLUMNS'))
-        except:
-            cr = (25, 80)
+        cr = (os.getenv('LINES', 25), os.getenv('COLUMNS', 80))
 
     return int(cr[1]), int(cr[0])


### PR DESCRIPTION
...code fix returns (LINES, COLUMNS) when the env vars are defined, (25, 80) when they are not defined. Previously, cr = (None, None) was returned when the env vars COLUMNS and LINES were not defined
