### PR TITLE
Added missing import for traceback

### DIFF
--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -20,6 +20,7 @@ release = 'barium'
 
 import os
 import sys
+import traceback
 from datetime import datetime
 
 from lettuce import fs


### PR DESCRIPTION
Traceback for outermost exception handler was failing due to missing 'import traceback'.

Now that's fixed I can see about finding out why I got an exception in the first place...

Thanks.
