### PR TITLE
Verbosity level 3 in commandline causing sys.exit(2)

### DIFF
--- a/lettuce/strings.py
+++ b/lettuce/strings.py
@@ -74,7 +74,7 @@ def remove_it(string, what):
 
 def column_width(string):
     l = 0
-    for c in string:
+    for c in unicode(string):
         if unicodedata.east_asian_width(c) in "WF":
             l += 2
         else:

--- a/tests/unit/test_strings.py
+++ b/tests/unit/test_strings.py
@@ -136,6 +136,13 @@ def test_column_width():
         10
     )
 
+def test_column_width_w_number_and_char():
+    "strings.column_width_w_number_and_char"
+    assert_equals(
+        strings.column_width( u"%s%c" % (u"4209", 0x4209)),
+        6
+    )
+    
 def test_rfill_simple():
     "strings.rfill simple case"
     assert_equals(


### PR DESCRIPTION
Hi!

Small fix to column_width counter to distinguish numerical input in scenario vs. actual unicode char.

Added testcase for testing this in column_width.
