### PR TITLE
With verbosity level 2 scenario outline cases don't give feedback how tests went

### DIFF
--- a/lettuce/plugins/scenario_names.py
+++ b/lettuce/plugins/scenario_names.py
@@ -18,6 +18,7 @@
 import os
 import sys
 from lettuce import core
+from lettuce import strings
 from lettuce.terrain import after
 from lettuce.terrain import before
 
@@ -33,6 +34,23 @@ def wrt(string):
 def print_scenario_running(scenario):
     wrt('%s ... ' % scenario.name)
 
+@after.each_feature
+def print_outline_result(feature):
+    if len(feature.scenarios[0].outlines):
+        if scenarios_and_its_fails.has_key(feature.scenarios[0]):
+            print 'FAILED'
+        else:
+            print 'OK'
+
+@after.outline
+def collect_outline_failures(scenario, order, outline, reasons_to_fail):
+    table = strings.dicts_to_string(scenario.outlines, scenario.keys)
+    lines = table.splitlines()
+    head = lines.pop(0)
+
+    if reasons_to_fail:
+        scenarios_and_its_fails[scenario] = reasons_to_fail[0]
+        failed_scenarios.append(scenario)
 
 @after.each_scenario
 def print_scenario_ran(scenario):

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -539,6 +539,49 @@ def test_output_with_successful_outline_colorless():
     )
 
 @with_setup(prepare_stdout)
+def test_output_with_successful_outline_verbosity_2():
+    "With verbosity level2 output, a successful outline scenario should print needed information."
+
+    runner = Runner(feature_name('success_outline'), verbosity=2)
+    runner.run()
+
+    assert_stdout_lines(
+        'fill a web form ... OK\n'
+        '\n'
+        '1 feature (1 passed)\n'
+        '3 scenarios (3 passed)\n'
+        '24 steps (24 passed)\n'
+        '(finished within 1 seconds)\n'
+    )
+
+@with_setup(prepare_stdout)
+def test_output_with_failful_outline_verbosity_2():
+    "With verbosity level2 output, a unsuccessful outline scenario should print needed information."
+
+    runner = Runner(feature_name('fail_outline'), verbosity=2)
+    runner.run()
+
+    assert_stdout_lines(
+        'fill a web form ... FAIL\n'
+        '\n'
+        "Traceback (most recent call last):\n"
+        '  File "%(lettuce_core_file)s", line %(call_line)d, in __call__\n'
+        "    ret = self.function(self.step, *args, **kw)\n"
+        '  File "%(step_file)s", line 30, in when_i_fill_the_field_x_with_y\n'
+        "    if field == 'password' and value == 'wee-9876':  assert False\n"
+        "AssertionError\n"
+        '\n'
+        '1 feature (0 passed)\n'
+        '3 scenarios (2 passed)\n'
+        '24 steps (1 failed, 4 skipped, 19 passed)\n'
+        '(finished within 1 seconds)\n' % {
+            'lettuce_core_file': lettuce_path('core.py'),
+            'step_file': abspath(lettuce_path('..', 'tests', 'functional', 'output_features', 'fail_outline', 'fail_outline_steps.py')),
+            'call_line':call_line,
+        }
+    )
+
+@with_setup(prepare_stdout)
 def test_output_with_successful_outline_colorful():
     "With colored output, a successful outline scenario should print beautifully."
 


### PR DESCRIPTION
Hi!

Added support for outline cases in verbosity level 2. Originally lettuce didn't print out is case OK or FAILED. Modified couple of functional testcases to prove that now it print states for case and also in FAILED case outputs error logs.
- Jani
