### PR TITLE
Remove 2.5 from .travis.yml because `sure` depends on `ipdb` which

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.5"
   - "2.6"
   - "2.7"
 # command to install dependencies


### PR DESCRIPTION
depends on `ipython` which depends on Python 2.6
