### PR TITLE
Fix for situation where 'localhost' is not resolvable

### DIFF
--- a/lettuce/django/server.py
+++ b/lettuce/django/server.py
@@ -107,8 +107,8 @@ class ThreadedServer(multiprocessing.Process):
 
     @staticmethod
     def get_real_address(address):
-        if address == '0.0.0.0':
-            address = 'localhost'
+        if address == '0.0.0.0' or address == 'localhost':
+            address = '127.0.0.1'
 
         return address
 

--- a/tests/integration/django/alfaces/donothing/features/simple-steps.py
+++ b/tests/integration/django/alfaces/donothing/features/simple-steps.py
@@ -28,7 +28,7 @@ def set_client():
 @step(r'I navigate to "(.*)"')
 def given_i_navigate_to_group1(step, url):
     url = django_url(url)
-    assert_equals(url, 'http://localhost:8000/')
+    assert_equals(url, 'http://127.0.0.1:8000/')
 
     raw = urllib2.urlopen(url).read()
     world.dom = html.fromstring(raw)

--- a/tests/integration/django/grocery/features/ability_to_fetch_admin_media.feature
+++ b/tests/integration/django/grocery/features/ability_to_fetch_admin_media.feature
@@ -1,7 +1,7 @@
 Feature: fetch admin media from lettuce + django builtin server
   Scenario: Running on port 7000
     Given my settings.py has "LETTUCE_SERVER_PORT" set to "7000"
-    Then I see that requesting "http://localhost:7000/media/css/base.css" gets "200"
+    Then I see that requesting "http://127.0.0.1:7000/media/css/base.css" gets "200"
 
   Scenario: Fetching admin media
     Given I navigate to "/admin/"


### PR DESCRIPTION
Hi,
I noticed that there are some problems when using "localhost" and having some problems with resolving it, like I do on some intranets. This patch fixes it by using "127.0.0.1" instead. (Without it, "python manage.py harvest" hanged in endless loop, waiting to resolve "localhost".)

Thanks for considering, keep up the great work at lettuce!
