### PR TITLE
Fix CLI exit code

### DIFF
--- a/lettuce/bin.py
+++ b/lettuce/bin.py
@@ -79,7 +79,7 @@ def main(args=sys.argv[1:]):
     )
 
     result = runner.run()
-    failed = bool(result or result.steps != result.steps_passed)
+    failed = result is None or result.steps != result.steps_passed
     raise SystemExit(int(failed))
 
 if __name__ == '__main__':


### PR DESCRIPTION
The 'lettuce' CLI, after a successful test run, was always exiting with
an exit status of 1 indicating an error. The main() function was
erroneously considering the test run a failure if the TotalResult
instance returned by runner.run() evaluated to True (which is always
does).

This issue was reported on the mailing list [1] by Dave Sykes. I ran
in to the same problem while running lettuce from tox which reports the
success/failure of a test run based on the exit status of the test
command (lettuce).

[1] https://groups.google.com/d/topic/lettuce-users/6Nu2QXE1MBc/discussion
