### PR TITLE
Allow multiple spaces after Scenario:.

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -151,7 +151,7 @@ class ScenarioDescription(object):
 
         for pline, part in enumerate(string.splitlines()):
             part = part.strip()
-            if re.match(u"%s:\W+" % language.scenario_separator + re.escape(scenario.name), part):
+            if re.match(u"%s:[ ]+" % language.scenario_separator + re.escape(scenario.name), part):
                 self.line = pline + 1
                 break
 


### PR DESCRIPTION
I've been experiencing problems with people sometimes including multiple spaces after "Scenario:", which causes lettuce to fail. This match will make it a bit more robust, while still not allowing line feed etc characters between the name of the scenario.
