### PR TITLE
Fixed parse_args call

### DIFF
--- a/lettuce/bin.py
+++ b/lettuce/bin.py
@@ -66,7 +66,7 @@ def main(args=sys.argv[1:]):
                       help='Write JUnit XML to this file. Defaults to '
                       'lettucetests.xml')
 
-    options, args = parser.parse_args()
+    options, args = parser.parse_args(args)
     if args:
         base_path = os.path.abspath(args[0])
 


### PR DESCRIPTION
Hey there,

This is just a little fix to have `parse_args` actually use the args if they're passed into the main function via kwarg.  

I'm using this exact scenario in salad, and finally found out where things were going wrong - this will fix it!

Thanks,
Steven
