### PR TITLE
Exception in case of an import problem is not helpful

### DIFF
--- a/lettuce/fs.py
+++ b/lettuce/fs.py
@@ -46,6 +46,8 @@ class FeatureLoader(object):
                 if 'empty module name' in err_msg.lower():
                     continue
                 else:
+                    e.args = ('{0} when importing {1}'
+                              .format(e, filename)),
                     raise e
 
             reload(module)  # always take fresh meat :)


### PR DESCRIPTION
If there's an import problem in the code which is being tested, the exception is not very helpful:

```
$ ./manage.py harvest
Creating test database for alias 'default'...
Destroying old test database 'default'...
Django's builtin server is running at 0.0.0.0:8000
Traceback (most recent call last):
  File "lettuce/django/management/commands/harvest.py", line 134, in handle
    result = runner.run()
  File "lettuce/__init__.py", line 131, in run
    self.loader.find_and_load_step_definitions()
  File "lettuce/fs.py", line 49, in find_and_load_step_definitions
    raise e
ValueError: Attempted relative import in non-package
Destroying test database for alias 'default'...
```
