### PR TITLE
Fix xunit plugin

### DIFF
--- a/lettuce/plugins/xunit_output.py
+++ b/lettuce/plugins/xunit_output.py
@@ -65,7 +65,8 @@ def enable(filename=None):
         if step.failed:
             cdata = doc.createCDATASection(step.why.traceback)
             failure = doc.createElement("failure")
-            failure.setAttribute("message", step.why.cause)
+            if hasattr(step.why, 'cause'):
+                failure.setAttribute("message", step.why.cause)
             failure.setAttribute("type", step.why.exception.__class__.__name__)
             failure.appendChild(cdata)
             tc.appendChild(failure)


### PR DESCRIPTION
xunit plugin causes an error when writing results into the xml file.

```
Traceback (most recent call last):
  File "/Users/arnihermann/github/ja-neo/lib/python2.7/site-packages/lettuce/registry.py", line 88, in call_hook
    callback(*args, **kw)
  File "/Users/arnihermann/github/ja-neo/lib/python2.7/site-packages/lettuce/plugins/xunit_output.py", line 68, in create_test_case_step
    failure.setAttribute("message", step.why.cause)
AttributeError: 'ReasonToFail' object has no attribute 'cause'

Died with 'ReasonToFail' object has no attribute 'cause'
Traceback (most recent call last):
  File "/Users/arnihermann/github/ja-neo/lib/python2.7/site-packages/lettuce/__init__.py", line 155, in run
    feature.run(self.scenarios, tags=self.tags, random=self.random))
  File "/Users/arnihermann/github/ja-neo/lib/python2.7/site-packages/lettuce/core.py", line 1135, in run
    scenarios_ran.extend(scenario.run(ignore_case))
  File "/Users/arnihermann/github/ja-neo/lib/python2.7/site-packages/lettuce/core.py", line 706, in run
    results.append(run_scenario(self, run_callbacks=True))
  File "/Users/arnihermann/github/ja-neo/lib/python2.7/site-packages/lettuce/core.py", line 684, in run_scenario
    all_steps, steps_passed, steps_failed, steps_undefined, reasons_to_fail = Step.run_all(self.steps, outline, run_callbacks, ignore_case)
  File "/Users/arnihermann/github/ja-neo/lib/python2.7/site-packages/lettuce/core.py", line 459, in run_all
    call_hook('after_each', 'step', step)
  File "/Users/arnihermann/github/ja-neo/lib/python2.7/site-packages/lettuce/registry.py", line 88, in call_hook
    callback(*args, **kw)
  File "/Users/arnihermann/github/ja-neo/lib/python2.7/site-packages/lettuce/plugins/xunit_output.py", line 68, in create_test_case_step
    failure.setAttribute("message", step.why.cause)
AttributeError: 'ReasonToFail' object has no attribute 'cause'
```

The patch fixes that by only writing the cause if the attribute is set.
