### PR TITLE
xunit output doesn't handle unicode strings

### DIFF
--- a/lettuce/plugins/xunit_output.py
+++ b/lettuce/plugins/xunit_output.py
@@ -63,10 +63,10 @@ def enable(filename=None):
             tc.appendChild(skip)
 
         if step.failed:
-            cdata = doc.createCDATASection(step.why.traceback)
+            cdata = doc.createCDATASection(step.why.traceback.decode('utf-8'))
             failure = doc.createElement("failure")
             if hasattr(step.why, 'cause'):
-                failure.setAttribute("message", step.why.cause)
+                failure.setAttribute("message", step.why.cause.decode('utf-8'))
             failure.setAttribute("type", step.why.exception.__class__.__name__)
             failure.appendChild(cdata)
             tc.appendChild(failure)
@@ -87,9 +87,9 @@ def enable(filename=None):
         tc.setAttribute("time", str(total_seconds((datetime.now() - scenario.outline_started))))
 
         for reason_to_fail in reasons_to_fail:
-            cdata = doc.createCDATASection(reason_to_fail.traceback)
+            cdata = doc.createCDATASection(reason_to_fail.traceback.decode('utf-8'))
             failure = doc.createElement("failure")
-            failure.setAttribute("message", reason_to_fail.cause)
+            failure.setAttribute("message", reason_to_fail.cause.decode('utf-8'))
             failure.appendChild(cdata)
             tc.appendChild(failure)
 


### PR DESCRIPTION
xunit output throws an exception when some of the tracebacks have unicode strings in them.

The proposed fix interprets the traceback string as utf8 before writing it to a `minidom` attribute.

Example of failure:

```
Traceback (most recent call last):
  File "/Users/arnihermann/github/ja-neo/src/lettuce/lettuce/registry.py", line 88, in call_hook
    callback(*args, **kw)
  File "/Users/arnihermann/github/ja-neo/src/lettuce/lettuce/plugins/xunit_output.py", line 105, in output_xml
    wrt_output(output_filename, doc.toxml())
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/dom/minidom.py", line 45, in toxml
    return self.toprettyxml("", "", encoding)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/dom/minidom.py", line 60, in toprettyxml
    return writer.getvalue()
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/StringIO.py", line 271, in getvalue
    self.buf += ''.join(self.buflist)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 314: ordinal not in range(128)

Traceback (most recent call last):
  File "/Users/arnihermann/github/ja-neo/bin/lettuce", line 9, in <module>
    load_entry_point('lettuce==0.2.10', 'console_scripts', 'lettuce')()
  File "/Users/arnihermann/github/ja-neo/src/lettuce/lettuce/bin.py", line 88, in main
    result = runner.run()
  File "/Users/arnihermann/github/ja-neo/src/lettuce/lettuce/__init__.py", line 172, in run
    call_hook('after', 'all', total)
  File "/Users/arnihermann/github/ja-neo/src/lettuce/lettuce/registry.py", line 88, in call_hook
    callback(*args, **kw)
  File "/Users/arnihermann/github/ja-neo/src/lettuce/lettuce/plugins/xunit_output.py", line 105, in output_xml
    wrt_output(output_filename, doc.toxml())
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/dom/minidom.py", line 45, in toxml
    return self.toprettyxml("", "", encoding)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/dom/minidom.py", line 60, in toprettyxml
    return writer.getvalue()
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/StringIO.py", line 271, in getvalue
    self.buf += ''.join(self.buflist)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 314: ordinal not in range(128)

```
