### PR TITLE
fixed a bug with unicode in SERVER_NAME

### DIFF
--- a/lettuce/django/management/commands/harvest.py
+++ b/lettuce/django/management/commands/harvest.py
@@ -142,7 +142,7 @@ class Command(BaseCommand):
             except LettuceServerException, e:
                 raise SystemExit(e)
 
-        os.environ['SERVER_NAME'] = server.address
+        os.environ['SERVER_NAME'] = str(server.address)
         os.environ['SERVER_PORT'] = str(server.port)
 
         failed = False


### PR DESCRIPTION
``` python
os.environ['SERVER_NAME'] = server.address
```

caused unicode string error in subprocess.py in my system (Windows 7). i think it must be

``` python
os.environ['SERVER_NAME'] = str(server.address)
```
