### PR TITLE
Use LiveServerTestCase when available

### DIFF
--- a/tests/integration/django/brocolis/leaves/features/modification.feature
+++ b/tests/integration/django/brocolis/leaves/features/modification.feature
@@ -1,0 +1,8 @@
+Feature: Live modification of view code
+  Scenario: Modifications do not apply
+    Given I change the view code
+    Then the root page says "OK"
+
+  Scenario: Modifications apply
+    Given I change the view code
+    Then the root page says "Changed"

--- a/tests/integration/django/brocolis/leaves/features/steps.py
+++ b/tests/integration/django/brocolis/leaves/features/steps.py
@@ -1,7 +1,11 @@
 import os
+from urllib import urlopen
 from django.conf import settings
+from django.http import HttpResponse
 from lettuce import step
+from lettuce.django import django_url
 from nose.tools import assert_equals
+
 @step(r'django has debug enabled')
 def debug_enabled(step):
     assert settings.DEBUG is True
@@ -17,3 +21,15 @@ def given_i_start_the_tests(step):
 @step(u'the environment variable "(.*)" is \'(.*)\'')
 def then_i_see_the_environment_variable_group1_is_group1(step, group1, group2):
     assert_equals(os.environ[group1], group2)
+
+@step(u'I change the view code')
+def change_view(step):
+    from leaves import views
+    def replacement(request):
+        return HttpResponse('Changed')
+    views.index = replacement
+
+@step(u'The root page says "(.*)"')
+def root_page_text(step, text):
+    response = urlopen(django_url('/')).read()
+    assert_equals(response, text)

--- a/tests/integration/django/brocolis/settings.py
+++ b/tests/integration/django/brocolis/settings.py
@@ -1,6 +1,6 @@
 DEBUG = True
 
-ROOT_URLCONF = 'couves.urls'
+ROOT_URLCONF = 'urls'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
@@ -17,3 +17,4 @@ INSTALLED_APPS = (
 )
 TEST_RUNNER = 'leaves.test_runner.TestRunner'
 SECRET_KEY = 'secret'
+STATIC_URL = '/static/'

--- a/tests/integration/django/brocolis/urls.py
+++ b/tests/integration/django/brocolis/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
-    url(r'', 'couves.leaves.views.index'),
+    url(r'', 'leaves.views.index'),
 )

--- a/tests/integration/test_brocolis.py
+++ b/tests/integration/test_brocolis.py
@@ -72,3 +72,25 @@ def test_harvest_uses_test_runner():
     assert "Custom test runner enabled." in out
 
     FileSystem.popd()
+
+def test_server_in_a_separate_process():
+    'harvest uses a separate server process by default'
+
+    FileSystem.pushd(current_directory, "django", "brocolis")
+
+    status, out = commands.getstatusoutput(
+        "python manage.py harvest -s 1 leaves/features/modification.feature")
+    assert_equals(status, 0, out)
+
+    FileSystem.popd()
+
+def test_server_in_process():
+    'harvest uses the same process if run with -T'
+
+    FileSystem.pushd(current_directory, "django", "brocolis")
+
+    status, out = commands.getstatusoutput(
+        "python manage.py harvest -T -s 2 leaves/features/modification.feature")
+    assert_equals(status, 0, out)
+
+    FileSystem.popd()


### PR DESCRIPTION
On Django 1.4+, LiveServerTestCase can be used instead of launching a separate server. That makes both tests and the tested application run in the same process, allowing for e.g. monkey-patching the code live.
