### PR TITLE
Marking the author string as unicode causes setup to fail for Python 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     name='lettuce',
     version='0.2.16',
     description='Behaviour Driven Development for python',
-    author=u'Gabriel Falcao',
+    author='Gabriel Falcao',
     author_email='gabriel@nacaolivre.org',
     url='http://lettuce.it',
     packages=get_packages(),


### PR DESCRIPTION
I simply removed it so lettuce will be installable using Python 3.2.
