### PR TITLE
Removed ipdb from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def get_packages():
 
     return packages
 
-required_modules = ['sure', 'fuzzywuzzy', 'ipdb']
+required_modules = ['sure', 'fuzzywuzzy']
 
 if sys.version_info[:2] < (2, 6):
     required_modules.append('multiprocessing')


### PR DESCRIPTION
ipdb is not required and makes django shell use ipython.
