### PR TITLE
Extract tags for each scenario by the Feature (issue #369).

### DIFF
--- a/tests/unit/test_feature_parser.py
+++ b/tests/unit/test_feature_parser.py
@@ -432,6 +432,24 @@ Feature: Taming the tag parser
     Then this scenario has only one tag
 """
 
+FEATURE22 = """
+Feature: one tag in the first scenario
+
+  @onetag
+  Scenario: This is the first scenario
+    Given I am parsed
+    Then this scenario has one tag
+"""
+
+FEATURE23 = """
+Feature: three tags in the first scenario
+
+  @onetag @another @$%^&even-weird_chars
+  Scenario: This is the first scenario
+    Given I am parsed
+    Then this scenario has three tags
+"""
+
 
 def test_feature_has_repr():
     "Feature implements __repr__ nicely"
@@ -618,11 +636,8 @@ def test_single_feature_single_tag():
     "All scenarios within a feature inherit the feature's tags"
     feature = Feature.from_string(FEATURE18)
 
-    # FIXME (mitgr81):  It seems worth the efficiency to not loop through the feature tags and
-    # check to see if every tag exists in the child.  The "right" fix might just be to not
-    # add the tag from the feature in the first scenario directly.
     assert that(feature.scenarios[0].tags).deep_equals([
-        'feature_runme', 'runme1', 'feature_runme'])
+        'runme1', 'feature_runme'])
 
     assert that(feature.scenarios[1].tags).deep_equals([
         'runme2', 'feature_runme'])
@@ -820,3 +835,21 @@ def test_scenario_post_email():
 
     scenario1.tags.should.be.empty
     scenario2.tags.should.be.empty
+
+def test_feature_first_scenario_tag_extraction():
+    ("A feature object should be able to find the single tag "
+     "belonging to the first scenario")
+    feature = Feature.from_string(FEATURE22)
+    
+    assert that(feature.scenarios[0].tags).deep_equals([
+        'onetag'])
+
+
+def test_feature_first_scenario_tags_extraction():
+    ("A feature object should be able to find the tags "
+     "belonging to the first scenario")
+    feature = Feature.from_string(FEATURE23)
+    
+    assert that(feature.scenarios[0].tags).deep_equals([
+        'onetag', 'another', '$%^&even-weird_chars'])
+

--- a/tests/unit/test_scenario_parsing.py
+++ b/tests/unit/test_scenario_parsing.py
@@ -454,32 +454,6 @@ def test_commented_scenarios():
     assert_equals(len(scenario.steps), 4)
 
 
-def test_scenario_has_tag():
-    ("A scenario object should be able to find at least one tag "
-     "on the first line")
-
-    scenario = Scenario.from_string(
-        SCENARIO1,
-        original_string=('@onetag\n' + SCENARIO1.strip()))
-
-    expect(scenario.tags).to.equal(['onetag'])
-
-
-def test_scenario_has_tags_singleline():
-    ("A scenario object should be able to find many tags "
-     "on the first line")
-
-    scenario = Scenario.from_string(
-        SCENARIO1,
-        original_string=(
-            '@onetag @another @$%^&even-weird_chars \n' + SCENARIO1.strip()))
-
-    expect(scenario.tags).to.equal([
-        'onetag',
-        'another',
-        '$%^&even-weird_chars',
-    ])
-
 
 def test_scenario_matches_tags():
     ("A scenario with tags should respond with True when "
@@ -487,7 +461,8 @@ def test_scenario_matches_tags():
 
     scenario = Scenario.from_string(
         SCENARIO1,
-        original_string=('@onetag\n@another-one\n' + SCENARIO1.strip()))
+        original_string=SCENARIO1.strip(),
+        tags=['onetag', 'another-one'])
 
     expect(scenario.tags).to.equal(['onetag', 'another-one'])
     assert scenario.matches_tags(['onetag'])
@@ -500,7 +475,8 @@ def test_scenario_matches_tags_fuzzywuzzy():
 
     scenario = Scenario.from_string(
         SCENARIO1,
-        original_string=('@anothertag\n@another-tag\n' + SCENARIO1.strip()))
+        original_string=SCENARIO1.strip(),
+        tags=['anothertag', 'another-tag'])
 
     assert scenario.matches_tags(['~another'])
 
@@ -511,7 +487,8 @@ def test_scenario_matches_tags_excluding():
 
     scenario = Scenario.from_string(
         SCENARIO1,
-        original_string=('@anothertag\n@another-tag\n' + SCENARIO1.strip()))
+        original_string=SCENARIO1.strip(),
+        tags=['anothertag', 'another-tag'])
 
     assert not scenario.matches_tags(['-anothertag'])
     assert scenario.matches_tags(['-foobar'])
@@ -544,7 +521,8 @@ def test_scenario_show_tags_in_its_representation():
 
     scenario = Scenario.from_string(
         SCENARIO1,
-        original_string=('@slow\n@firefox\n@chrome\n' + SCENARIO1.strip()))
+        original_string=SCENARIO1.strip(),
+        tags=['slow', 'firefox', 'chrome'])
 
     expect(scenario.represented()).to.equal(
         u'  @slow @firefox @chrome\n  '


### PR DESCRIPTION
The previous option (using a regex search in the whole
 file to look for tags in each new scenario) was quite
 slow.

This commit is especially interesting for projects with
 feature file of more than 20K.

This commit closes the issue #369
