### PR TITLE
display list of failed scenarios in test run report

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -1235,6 +1235,8 @@ class TotalResult(object):
         self.steps_undefined = 0
         self._proposed_definitions = []
         self.steps = 0
+        # store the scenario names that failed, with their location
+        self.failed_scenario_locations = []
         for feature_result in self.feature_results:
             for scenario_result in feature_result.scenario_results:
                 self.scenario_results.append(scenario_result)
@@ -1244,6 +1246,8 @@ class TotalResult(object):
                 self.steps_undefined += len(scenario_result.steps_undefined)
                 self.steps += scenario_result.total_steps
                 self._proposed_definitions.extend(scenario_result.steps_undefined)
+                if len(scenario_result.steps_failed) > 0:
+                    self.failed_scenario_locations.append(scenario_result.scenario.represented())
 
     def _filter_proposed_definitions(self):
         sentences = []

--- a/lettuce/plugins/colored_shell_output.py
+++ b/lettuce/plugins/colored_shell_output.py
@@ -251,6 +251,17 @@ def print_end(total):
 
             wrt("\n")
 
+    if total.failed_scenario_locations:
+        # print list of failed scenarios, with their file and line number
+        wrt("\n")
+        wrt("\033[1;31m")
+        wrt("List of failed scenarios:\n")
+        wrt("\033[0;31m")
+        for scenario in total.failed_scenario_locations:
+            wrt(scenario)
+        wrt("\033[0m")
+        wrt("\n")
+
 
 def print_no_features_found(where):
     where = core.fs.relpath(where)

--- a/lettuce/plugins/shell_output.py
+++ b/lettuce/plugins/shell_output.py
@@ -143,6 +143,13 @@ def print_end(total):
             wrt("    assert False, 'This step must be implemented'\n")
 
 
+    if total.failed_scenario_locations:
+        # print list of failed scenarios, with their file and line number
+        wrt("\nList of failed scenarios:\n")
+        for scenario in total.failed_scenario_locations:
+            wrt(scenario)
+        wrt("\n")
+
 def print_no_features_found(where):
     where = core.fs.relpath(where)
     if not where.startswith(os.sep):

--- a/tests/functional/test_behave_as_handling.py
+++ b/tests/functional/test_behave_as_handling.py
@@ -121,7 +121,12 @@ def test_failing_tables_behave_as_feature():
     '\n'
     '1 feature (0 passed)\n'
     '2 scenarios (0 passed)\n'
-    '6 steps (2 failed, 4 skipped, 0 passed)\n' % {
+    '6 steps (2 failed, 4 skipped, 0 passed)\n'
+    '\n'
+    'List of failed scenarios:\n'
+    '  Scenario: Regular numbers                        # tests/functional/behave_as_features/3rd_failing_steps/3rd_failing_steps.feature:6\n'
+    '  Scenario: Shorter version of the scenario above  # tests/functional/behave_as_features/3rd_failing_steps/3rd_failing_steps.feature:12\n'
+    '\n' % {
             'lettuce_core_file': lettuce_path('core.py'),
             'step_file': abspath(lettuce_path('..', 'tests', 'functional', 'behave_as_features', '3rd_failing_steps', 'failing_step_definitions.py')),
             'call_line':call_line,

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -475,7 +475,11 @@ def test_output_with_failed_colorless_with_table():
         "\n"
         "@step(u'And this one does not even has definition')\n"
         "def and_this_one_does_not_even_has_definition(step):\n"
-        "    assert False, 'This step must be implemented'\n") % {
+        "    assert False, 'This step must be implemented'\n"
+        "\n"
+        "List of failed scenarios:\n"
+        "  Scenario: See it fail                       # tests/functional/output_features/failed_table/failed_table.feature:2\n"
+        "\n") % {
             'lettuce_core_file': lettuce_path('core.py'),
             'step_file': abspath(lettuce_path('..', 'tests', 'functional', 'output_features', 'failed_table', 'failed_table_steps.py')),
             'call_line': call_line,
@@ -523,7 +527,11 @@ def test_output_with_failed_colorful_with_table():
         "@step(u'And this one does not even has definition')\n"
         "def and_this_one_does_not_even_has_definition(step):\n"
         "    assert False, 'This step must be implemented'\033[0m"
-        "\n" % {
+        "\n"
+        "\n"
+        "\033[1;31mList of failed scenarios:\n"
+        "\033[0;31m  Scenario: See it fail                       # tests/functional/output_features/failed_table/failed_table.feature:2\n"
+        "\033[0m\n" % {
             'lettuce_core_file': lettuce_path('core.py'),
             'step_file': abspath(lettuce_path('..', 'tests', 'functional', 'output_features', 'failed_table', 'failed_table_steps.py')),
             'call_line': call_line,
@@ -641,7 +649,11 @@ def test_output_with_failful_outline_colorless():
         '\n'
         '1 feature (0 passed)\n'
         '3 scenarios (2 passed)\n'
-        '24 steps (1 failed, 4 skipped, 19 passed)\n' % {
+        '24 steps (1 failed, 4 skipped, 19 passed)\n'
+        '\n'
+        'List of failed scenarios:\n'
+        '  Scenario Outline: fill a web form                           # tests/functional/output_features/fail_outline/fail_outline.feature:6\n'
+        '\n' % {
             'lettuce_core_file': lettuce_path('core.py'),
             'step_file': abspath(lettuce_path('..', 'tests', 'functional', 'output_features', 'fail_outline', 'fail_outline_steps.py')),
             'call_line': call_line,
@@ -687,7 +699,11 @@ def test_output_with_failful_outline_colorful():
         '\n'
         "\033[1;37m1 feature (\033[0;31m0 passed\033[1;37m)\033[0m\n"
         "\033[1;37m3 scenarios (\033[1;32m2 passed\033[1;37m)\033[0m\n"
-        "\033[1;37m24 steps (\033[0;31m1 failed\033[1;37m, \033[0;36m4 skipped\033[1;37m, \033[1;32m19 passed\033[1;37m)\033[0m\n" % {
+        "\033[1;37m24 steps (\033[0;31m1 failed\033[1;37m, \033[0;36m4 skipped\033[1;37m, \033[1;32m19 passed\033[1;37m)\033[0m\n"
+        "\n"
+        "\033[1;31mList of failed scenarios:\n"
+        "\033[0;31m  Scenario Outline: fill a web form                           # tests/functional/output_features/fail_outline/fail_outline.feature:6\n"
+        "\033[0m\n" % {
             'lettuce_core_file': lettuce_path('core.py'),
             'step_file': abspath(lettuce_path('..', 'tests', 'functional', 'output_features', 'fail_outline', 'fail_outline_steps.py')),
             'call_line': call_line,
@@ -1237,10 +1253,10 @@ def test_output_background_with_success_colorless():
         '  I want to automate its test                 # tests/functional/bg_features/simple/simple.feature:4\n'
         '\n'
         '  Background:\n'
-        '    Given the variable "X" holds 2            # tests/functional/test_runner.py:1223\n'
+        '    Given the variable "X" holds 2            # tests/functional/test_runner.py:1239\n'
         '\n'
         '  Scenario: multiplication changing the value # tests/functional/bg_features/simple/simple.feature:9\n'
-        '    Given the variable "X" is equal to 2      # tests/functional/test_runner.py:1223\n'
+        '    Given the variable "X" is equal to 2      # tests/functional/test_runner.py:1239\n'
         '\n'
         '1 feature (1 passed)\n'
         '1 scenario (1 passed)\n'
@@ -1272,12 +1288,12 @@ def test_output_background_with_success_colorful():
         '\033[1;37m  I want to automate its test                 \033[1;30m# tests/functional/bg_features/simple/simple.feature:4\033[0m\n'
         '\n'
         '\033[1;37m  Background:\033[0m\n'
-        '\033[1;30m    Given the variable "X" holds 2            \033[1;30m# tests/functional/test_runner.py:1258\033[0m\n'
-        '\033[A\033[1;32m    Given the variable "X" holds 2            \033[1;30m# tests/functional/test_runner.py:1258\033[0m\n'
+        '\033[1;30m    Given the variable "X" holds 2            \033[1;30m# tests/functional/test_runner.py:1274\033[0m\n'
+        '\033[A\033[1;32m    Given the variable "X" holds 2            \033[1;30m# tests/functional/test_runner.py:1274\033[0m\n'
         '\n'
         '\033[1;37m  Scenario: multiplication changing the value \033[1;30m# tests/functional/bg_features/simple/simple.feature:9\033[0m\n'
-        '\033[1;30m    Given the variable "X" is equal to 2      \033[1;30m# tests/functional/test_runner.py:1258\033[0m\n'
-        '\033[A\033[1;32m    Given the variable "X" is equal to 2      \033[1;30m# tests/functional/test_runner.py:1258\033[0m\n'
+        '\033[1;30m    Given the variable "X" is equal to 2      \033[1;30m# tests/functional/test_runner.py:1274\033[0m\n'
+        '\033[A\033[1;32m    Given the variable "X" is equal to 2      \033[1;30m# tests/functional/test_runner.py:1274\033[0m\n'
         '\n'
         '\033[1;37m1 feature (\033[1;32m1 passed\033[1;37m)\033[0m\n'
         '\033[1;37m1 scenario (\033[1;32m1 passed\033[1;37m)\033[0m\n'
@@ -1407,4 +1423,4 @@ def test_output_with_undefined_steps_colorful():
         'def when_this_test_step_is_undefined(step):\n'
         "    assert False, 'This step must be implemented'\x1b[0m\n"
     )
-    
+


### PR DESCRIPTION
After running all tests, display list of failed scenarios, with file and line number.
Developers can then go through the failed scenarios and tag them
appropriately, so that while debugging they can run only the failed subset.
