### PR TITLE
Normalize after* hook behaviour

### DIFF
--- a/lettuce/plugins/colored_shell_output.py
+++ b/lettuce/plugins/colored_shell_output.py
@@ -58,7 +58,7 @@ def write_out(what):
 
 @before.each_step
 def print_step_running(step):
-    if not step.defined_at:
+    if not step.defined_at or not step.display:
         return
 
     color = '\033[1;30m'
@@ -76,6 +76,8 @@ def print_step_running(step):
 
 @after.each_step
 def print_step_ran(step):
+    if not step.display:
+        return
     if step.scenario and step.scenario.outlines and (step.failed or step.passed or step.defined_at):
         return
 

--- a/lettuce/plugins/shell_output.py
+++ b/lettuce/plugins/shell_output.py
@@ -32,6 +32,9 @@ def wrt(what):
 
 @after.each_step
 def print_step_running(step):
+    if not step.display:
+        return
+
     wrt(step.represent_string(step.original_sentence).rstrip())
     if not step.defined_at:
         wrt(" (undefined)")

--- a/tests/functional/output_features/system_exiting_error/system_exiting_error.feature
+++ b/tests/functional/output_features/system_exiting_error/system_exiting_error.feature
@@ -1,0 +1,4 @@
+Feature: A system-exiting error
+  Scenario: Raise a system-exiting error
+    Given a system-exiting error is raised
+    Then this step is never reached

--- a/tests/functional/output_features/system_exiting_error/system_exiting_error_steps.py
+++ b/tests/functional/output_features/system_exiting_error/system_exiting_error_steps.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from lettuce import step
+
+@step(u'a system-exiting error is raised')
+def raise_system_exiting_error(step):
+    raise KeyboardInterrupt

--- a/tests/functional/test_after_hooks.py
+++ b/tests/functional/test_after_hooks.py
@@ -1,0 +1,100 @@
+"""Make sure after.each_step, after.outline, after.each_scenario, and
+after_each feature hooks are invoked, regardless of whether a test passes.
+"""
+
+from mock import MagicMock
+from lettuce import Runner, after
+from nose.tools import assert_equals, assert_raises, with_setup
+from os.path import dirname, join, abspath
+from tests.asserts import prepare_stdout, prepare_stderr
+
+def define_hooks(mock):
+    @after.each_feature    
+    def after_each_feature(feature):
+        mock.after_each_feature()
+
+    @after.each_scenario    
+    def after_each_scenario(scenario):
+        mock.after_each_scenario()
+
+    @after.each_step    
+    def after_each_step(step):
+        mock.after_each_step()
+
+    @after.outline    
+    def after_outline(scenario, order, outline, reasons_to_fail):
+        mock.after_outline()
+
+def get_after_hook_mock():
+    mock = MagicMock()
+    mock.after_each_feature = MagicMock()
+    mock.after_each_scenario = MagicMock()
+    mock.after_each_step = MagicMock()
+    mock.after_outline = MagicMock()
+    return mock
+
+current_dir = abspath(dirname(__file__))
+ojoin = lambda *x: join(current_dir, 'output_features', *x)
+def joiner(callback, name):
+    return callback(name, "%s.feature" % name)
+feature_name = lambda name: joiner(ojoin, name)
+
+def run_feature(feature, feature_will_fail, failfast,
+             after_each_feature_count, after_each_scenario_count,
+             after_each_step_count, after_outline_count):
+    mock = get_after_hook_mock()
+    define_hooks(mock)
+    runner = Runner(feature_name(feature), failfast=failfast) 
+    if feature_will_fail:
+        try:
+            runner.run()
+        except:
+            pass
+    else:
+        runner.run()
+    assert_equals(mock.after_each_feature.call_count, after_each_feature_count)
+    assert_equals(mock.after_each_scenario.call_count, after_each_scenario_count)
+    assert_equals(mock.after_each_step.call_count, after_each_step_count)
+    assert_equals(mock.after_outline.call_count, after_outline_count)
+
+@with_setup(prepare_stdout)
+def test_success_outline():
+    run_feature('success_outline', False, False, 1, 1, 24, 3)
+
+@with_setup(prepare_stdout)
+def test_success_outline_failfast():
+    run_feature('success_outline', False, True, 1, 1, 24, 3)
+
+@with_setup(prepare_stdout)
+def test_fail_outline():
+    run_feature('fail_outline', True, False, 1, 1, 24, 3)
+
+@with_setup(prepare_stdout)
+def test_fail_outline_failfast():
+    run_feature('fail_outline', True, True, 1, 1, 12, 2)
+
+@with_setup(prepare_stdout)
+def test_success_non_outline():
+    run_feature('success_table', False, False, 1, 1, 5, 0)
+
+@with_setup(prepare_stdout)
+def test_success_non_outline_failfast():
+    run_feature('success_table', False, True, 1, 1, 5, 0)
+
+@with_setup(prepare_stdout)
+def test_fail_non_outline():
+    run_feature('failed_table', True, False, 1, 1, 5, 0)
+
+@with_setup(prepare_stdout)
+def test_fail_non_outline_failfast():
+    run_feature('failed_table', True, True, 1, 1, 2, 0)
+
+@with_setup(prepare_stderr)
+@with_setup(prepare_stdout)
+def test_fail_system_exiting_non_outline():
+    run_feature('system_exiting_error', True, False, 1, 1, 1, 0)
+
+@with_setup(prepare_stdout)
+def test_fail_system_exiting_failfast_non_outline():
+    run_feature('system_exiting_error', True, True, 1, 1, 1, 0)
+


### PR DESCRIPTION
Previously, the behaviour of after\* hooks was inconsistent if an exception
was raised. If a system-exiting exception was raised (e.g., KeyboardInterrupt,
a result of pressing Ctrl-C), after_each.feature and after_each.scenario ran
only in failfast mode, while after.outline never ran at all, and
after_each.step always ran. after.outline never ran on any error when in
failfast mode. This was undocumented, unexpected, and problematic, since
the hooks can be used to clean up altered state, something we still want to
happen even if the test is cancelled or a step fails.

after_each.feature, after_each.scenario, after.outline and after_each.step
hooks will now run on a step failure on a system-exiting exception in failfast
mode and outside of failfast mode. The output plugins relied on the previous
behaviour and have been modified to make sure the output format does not
change. Tests have been added for the new hook behaviour.
