### PR TITLE
ReasonToFail object has no cause attribute when exception had no message...

### DIFF
--- a/lettuce/plugins/xunit_output.py
+++ b/lettuce/plugins/xunit_output.py
@@ -100,7 +100,7 @@ def enable(filename=None):
         for reason_to_fail in reasons_to_fail:
             cdata = doc.createCDATASection(reason_to_fail.traceback)
             failure = doc.createElement("failure")
-            failure.setAttribute("message", reason_to_fail.cause)
+            failure.setAttribute("message", reason_to_fail.cause if hasattr(reason_to_fail,"cause") else "")
             failure.appendChild(cdata)
             tc.appendChild(failure)
 


### PR DESCRIPTION
... defined

This is the fix for the
https://github.com/gabrielfalcao/lettuce/issues/384
