### PR TITLE
Tags applied to features are inherited by scenarios

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -957,7 +957,7 @@ class Feature(object):
     def _add_myself_to_scenarios(self):
         for scenario in self.scenarios:
             scenario.feature = self
-            if scenario.tags and self.tags:
+            if scenario.tags is not None and self.tags:
                 scenario.tags.extend(self.tags)
 
     def _find_tags_in(self, original_string):

--- a/tests/unit/test_step_runner.py
+++ b/tests/unit/test_step_runner.py
@@ -102,6 +102,18 @@ Feature: When using behave_as, the new steps have the same scenario
     Given I have a step which calls the "access the scenario" step with behave_as
 """
 
+FEATURE10 = """ 
+@tag
+Feature: Many scenarios
+
+  Scenario: 1st one
+    Given I have a defined step
+
+  Scenario: 2nd one
+    Given I have a defined step
+"""
+
+
 def step_runner_environ():
     "Make sure the test environment is what is expected"
 
@@ -226,7 +238,7 @@ def test_steps_are_aware_of_its_definitions():
 
     step1 = scenario_result.steps_passed[0]
 
-    assert_equals(step1.defined_at.line, 112)
+    assert_equals(step1.defined_at.line, 124)
     assert_equals(step1.defined_at.file, core.fs.relpath(__file__.rstrip("c")))
 
 @with_setup(step_runner_environ)
@@ -320,6 +332,23 @@ def test_feature_can_run_only_specified_scenarios_in_tags():
     assert result.scenario_results
 
     assert_equals(scenarios_ran, ['1st one', '3rd one'])
+
+
+@with_setup(step_runner_environ)
+def test_scenarios_inherit_feature_tags():
+    "Tags applied to features are inherited by scenarios"
+    feature = Feature.from_string(FEATURE10)
+
+    scenarios_ran = []
+
+    @after.each_scenario
+    def just_register(scenario):
+        scenarios_ran.append(scenario.name)
+
+    result = feature.run(tags=['tag'])
+    assert result.scenario_results
+
+    assert_equals(scenarios_ran, ['1st one', '2nd one'])
 
 
 @with_setup(step_runner_environ)


### PR DESCRIPTION
This PR allows scenarios to inherit tags from their features.  Before, a feature tag was applied only to (a) the first scenario in a feature or (b) scenarios in the feature that already had at least one tag.  Now, all scenarios in a feature inherit the feature's tags.
