### PR TITLE
Fix exception with xunit and unicode chars.

### DIFF
--- a/lettuce/strings.py
+++ b/lettuce/strings.py
@@ -24,8 +24,6 @@ def utf8_string(s):
     if isinstance(s, str):
         s = s.decode("utf-8")
 
-    elif isinstance(s, unicode):
-        s = s.encode("utf-8")
     return s
 
 

--- a/tests/functional/output_features/xunit_unicode_and_bytestring_mixing/xunit_unicode_and_bytestring_mixing.feature
+++ b/tests/functional/output_features/xunit_unicode_and_bytestring_mixing/xunit_unicode_and_bytestring_mixing.feature
@@ -7,3 +7,6 @@ Feature: Mixing of Unicode & bytestrings in xunit xml output
 
 Scenario Outline: It should pass too
     Given non ascii characters "Тест" in step
+
+Scenario Outline: Exception should not raise an UnicodeDecodeError
+    Given non ascii characters "Тест" in exception

--- a/tests/functional/output_features/xunit_unicode_and_bytestring_mixing/xunit_unicode_and_bytestring_mixing_steps.py
+++ b/tests/functional/output_features/xunit_unicode_and_bytestring_mixing/xunit_unicode_and_bytestring_mixing_steps.py
@@ -9,3 +9,8 @@ def non_ascii_characters_in_outline(step, first):
 @step(u'Non ascii characters "(.*)" in step')
 def define_nonascii_chars(step, word):
     assert True
+
+
+@step(u'Non ascii characters "(.*)" in exception')
+def raise_nonascii_chars(step, word):
+    raise Exception(word)


### PR DESCRIPTION
When running lettuce with xunit it throws an UnicodeDecodeException when an
exception is thrown with non-ascii characters in it. This commit adds a test
and fixes the issue. The function utf8_string now always returns an unicode
string.
