### PR TITLE
Don't Run Feature Hooks If No Feature Scenarios Run

### DIFF
--- a/tests/unit/test_terrain.py
+++ b/tests/unit/test_terrain.py
@@ -41,6 +41,17 @@ Feature: Before and After callbacks all along lettuce
 '''
 
 
+FEATURE3 = '''
+Feature: Before and After callbacks all along lettuce
+    @tag1
+    Scenario: Before and After scenarios
+        Given I append "during" to states
+
+    @tag2
+    Scenario: Again
+        Given I append "during" to states
+'''
+
 def test_world():
     "lettuce.terrain.world can be monkey patched at will"
 
@@ -135,6 +146,24 @@ def test_after_each_feature_is_executed_before_each_feature():
     assert_equals(
         world.feature_steps,
         ['before', 'during', 'during', 'after'],
+    )
+
+
+def test_feature_hooks_not_invoked_if_no_scenarios_run():
+    feature = Feature.from_string(FEATURE3)
+
+    world.feature_steps = []
+    feature.run(tags=['tag1'])
+    assert_equals(
+        world.feature_steps,
+        ['before', 'during', 'after']
+    )
+
+    world.feature_steps = []
+    feature.run(tags=['tag3'])
+    assert_equals(
+        world.feature_steps,
+        []
     )
 
 


### PR DESCRIPTION
Feature scenarios may be precluded from running because of their
tags or a filter specified using the --scenarios command line argument.
It may be the case that no scenario in a feature runs at all. Previously,
the before and after hooks would still run in that case. This can be
problematic, as the hooks may be used to perform expensive set up or tear
down steps, which would run pointlessly if the scenarios that depend on them
don't run.

Change the behaviour so that before and after feature hooks run only if
scenarios in that feature run.

Testing: Added unit tests
