### PR TITLE
Do not use undocumented WSGIServerException

### DIFF
--- a/lettuce/django/server.py
+++ b/lettuce/django/server.py
@@ -30,7 +30,6 @@ from django.core.handlers.wsgi import WSGIHandler
 from django.core.servers.basehttp import WSGIServer
 from django.core.servers.basehttp import ServerHandler
 from django.core.servers.basehttp import WSGIRequestHandler
-from django.core.servers.basehttp import WSGIServerException
 try:
     from django.core.servers.basehttp import AdminMediaHandler
 except ImportError:
@@ -55,7 +54,7 @@ def create_mail_queue():
     return mail.queue
 
 
-class LettuceServerException(WSGIServerException):
+class LettuceServerException(socket.error):
     pass
 
 keep_running = True
@@ -191,7 +190,7 @@ class ThreadedServer(multiprocessing.Process):
         try:
             server_address = (self.address, self.port)
             httpd = WSGIServer(server_address, MutedRequestHandler)
-        except WSGIServerException:
+        except socket.error:
             raise LettuceServerException(
                 "the port %d already being used, could not start " \
                 "django's builtin server on it" % self.port,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.4.1
+Django==1.5.5
 Jinja2==2.6
 Pygments==1.5
 Sphinx==1.1.3

--- a/tests/integration/django/celeries/settings.py
+++ b/tests/integration/django/celeries/settings.py
@@ -15,3 +15,4 @@ INSTALLED_APPS = (
     'lettuce.django',
     'leaves',
 )
+SECRET_KEY = 'secret'

--- a/tests/integration/django/couves/settings.py
+++ b/tests/integration/django/couves/settings.py
@@ -15,3 +15,4 @@ INSTALLED_APPS = (
     'lettuce.django',
     'leaves',
 )
+SECRET_KEY = 'secret'


### PR DESCRIPTION
Lettuce fails to start on Django 1.6 due to removal of the undocumented `WSGIServerException`, see [release notes](https://docs.djangoproject.com/en/1.6/releases/1.6/). The patch fixes Lettuce's dependency on it and bumps the Django version in the requirements to 1.5.
