### PR TITLE
Fix __repr__ for core classes

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -332,8 +332,11 @@ class Step(object):
         lines = strings.dicts_to_string(self.hashes, self.keys).splitlines()
         return u"\n".join([(u" " * self.table_indentation) + line for line in lines]) + "\n"
 
-    def __repr__(self):
+    def __unicode__(self):
         return u'<Step: "%s">' % self.sentence
+
+    def __repr__(self):
+        return unicode(self).encode('utf-8')
 
     def _parse_remaining_lines(self, lines):
         multiline = strings.parse_multiline(lines)
@@ -622,8 +625,11 @@ class Scenario(object):
     def _calc_value_length(self, data):
         return self._calc_list_length(data.values())
 
-    def __repr__(self):
+    def __unicode__(self):
         return u'<Scenario: "%s">' % self.name
+
+    def __repr__(self):
+        return unicode(self).encode('utf-8')
 
     def matches_tags(self, tags):
         if tags is None:
@@ -995,8 +1001,11 @@ class Feature(object):
         found = regex.findall(item)
         return found
 
-    def __repr__(self):
+    def __unicode__(self):
         return u'<%s: "%s">' % (self.language.first_of_feature, self.name)
+
+    def __repr__(self):
+        return unicode(self).encode('utf-8')
 
     def get_head(self):
         return u"%s: %s" % (self.language.first_of_feature, self.name)


### PR DESCRIPTION
**repr** should return str not unicode

If **repr** returns unicode, calling repr on the object will force python to convert it to str using ascii codec which has high risk of failure:

```
>>> class A(object):
...     def __repr__(self):
...         return u"é"
... 
>>> A()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 0: ordinal not in range(128)
```

This can be an issue:
Traceback (most recent call last):
  File "./venv/lib/python2.6/site-packages/lettuce/django/management/commands/harvest.py", line 167, in handle
    result = runner.run()
  File "./venv/lib/python2.6/site-packages/lettuce/**init**.py", line 183, in run
    call_hook('after', 'all', total)
  File "./venv/lib/python2.6/site-packages/lettuce/registry.py", line 88, in call_hook
    callback(_args, *_kw)
  File "./venv/lib/python2.6/site-packages/lettuce/plugins/reporter.py", line 30, in print_end
    self.wrt(str(reason.step))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 83-84: ordinal not in range(128)
