### PR TITLE
Catch ImportError to prevent cryptic stacktrace

### DIFF
--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -161,6 +161,9 @@ class Runner(object):
         # that we don't even want to test.
         try:
             self.loader.find_and_load_step_definitions()
+        except ImportError, e:
+            print "Error loading step definitions, did you create some?"
+            return
         except StepLoadingError, e:
             print "Error loading step definitions:\n", e
             return


### PR DESCRIPTION
Writing my first feature/steps ever, I tried to launch `lettuce` before writing my `steps.py` file.
Shame on me! But the error is cryptic:

    Traceback (most recent call last):
     File "/usr/local/bin/lettuce", line 9, in <module>
       load_entry_point('lettuce==0.2.19', 'console_scripts', 'lettuce')()
     File "/usr/local/lib/python2.7/dist-packages/lettuce/bin.py", line 106, in main
       result = runner.run()
     File "/usr/local/lib/python2.7/dist-packages/lettuce/__init__.py", line 137, in run
       self.loader.find_and_load_step_definitions()
     File "/usr/local/lib/python2.7/dist-packages/lettuce/fs.py", line 49, in find_and_load_step_definitions
       module = __import__(to_load)
     File "/data/prj/microalg/github/texttest/source/lib/default/gtkgui/textinfo.py", line 8, in <module>
       from default import performance
    ImportError: No module named default

I'm aware this might not be the cleanest fix, but it works for me.
Sorry, I don't have the time to see if I can write a scenario about this.