### PR TITLE
plugin/reporter.py: use 'unicode' instead of 'str'

### DIFF
--- a/lettuce/plugins/reporter.py
+++ b/lettuce/plugins/reporter.py
@@ -28,7 +28,7 @@ class Reporter(object):
             self.wrt("\n")
             for scenario in self.failed_scenarios:
                 reason = self.scenarios_and_its_fails[scenario]
-                self.wrt(str(reason.step))
+                self.wrt(unicode(reason.step))
                 self.wrt("\n")
                 self.wrt(reason.traceback)
 


### PR DESCRIPTION
I get a `UnicodeEncodeError: 'ascii' codec can't encode…` when a scenario fails.
I'm French and use accented steps. Maybe that's the reason.
This fix works for me.
