### PR TITLE
Support _ in update step property names

### DIFF
--- a/lettuce/django/steps/models.py
+++ b/lettuce/django/steps/models.py
@@ -250,8 +250,8 @@ def models_exist(model, data, queryset=None):
 
 for txt in (
     (r'I have(?: an?)? ([a-z][a-z0-9_ ]*) in the database:'),
-    (r'I update(?: an?)? existing ([a-z][a-z0-9_ ]*) by ([a-z]+) in the '
-     'database:'),
+    (r'I update(?: an?)? existing ([a-z][a-z0-9_ ]*) by ([a-z][a-z0-9_]*) '
+     'in the database:'),
 ):
     @step(txt)
     def write_models_generic(step, model, field=None):
@@ -260,14 +260,26 @@ for txt in (
             | name | bar  |
             | Baz  | Quux |
 
-        And I update existing foos in the database:
+        And I update existing foos by pk in the database:
             | pk | name |
             | 1  | Bar  |
 
         The generic method can be overridden for a specific model by defining a
-        function write_badgers(step, data, field), which creates and updates
+        function write_badgers(step, field), which creates and updates
         the Badger model and decorating it with the writes_models(model_class)
         decorator.
+
+            @writes_models(Profile)
+            def write_profile(step, field):
+                '''Creates a Profile model'''
+
+                for hash_ in hashes_data(step):
+                    if field:
+                        profile = Profile.objects.get(**{field: hash_[field]})
+                    else:
+                        profile = Profile()
+
+                    ...
         """
 
         model = get_model(model)


### PR DESCRIPTION
Allows us to specify fields like user_id or user__username when updating
steps.

Also update the documentation to be more correct and include an example.
