### PR TITLE
add make to whitelist_externals since tox does not install it

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,4 @@ envlist = py26, py27
 commands =
     pip install --use-mirrors -q -r requirements.txt
     make unit functional
+whitelist_externals = make


### PR DESCRIPTION
<http://tox.readthedocs.org/en/latest/config.html#confval-whitelist_externals=MULTI-LINE-LIST>
once pull request #461 is in, we need to add `make` to the whitelist so `tox` does not warn the user about it.