### PR TITLE
make StepDict.items() deterministic.

### DIFF
--- a/lettuce/registry.py
+++ b/lettuce/registry.py
@@ -21,6 +21,11 @@ import traceback
 
 from lettuce.exceptions import StepLoadingError
 
+try:
+    from collections import OrderedDict
+except ImportError:  # py26
+    from ordereddict import OrderedDict
+
 world = threading.local()
 world._set = False
 
@@ -40,7 +45,7 @@ class CallbackDict(dict):
             for callback_list in action_dict.values():
                 callback_list[:] = []
 
-class StepDict(dict):
+class StepDict(OrderedDict):
     def __init__(self, *args, **kwargs):
         super(StepDict, self).__init__(*args, **kwargs)
         self._compiled = {}

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ required_modules = ['sure', 'fuzzywuzzy', 'python-subunit']
 if sys.version_info[:2] < (2, 6):
     required_modules.append('multiprocessing')
 
+if sys.version_info[:2] < (2, 7):
+    required_modules.append('ordereddict')
+
 if os.name.lower() == 'nt':
     required_modules.append('colorama')
 

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -18,6 +18,7 @@ from lettuce.registry import _function_matches, StepDict
 from lettuce.exceptions import StepLoadingError
 
 from nose.tools import assert_raises, assert_equal
+import random
 
 
 def test_function_matches_compares_with_abs_path():
@@ -56,6 +57,16 @@ def test_StepDict_load_a_step_return_the_given_function():
     steps = StepDict()
     func = lambda: ""
     assert_equal(steps.load("another step", func), func)
+
+def test_StepDict_return_items_in_same_order_loaded():
+    u"lettuce.STEP_REGISTRY.load(step, func) returns func"
+    steps = StepDict()
+    func = lambda: ""
+    regexes = ["one", "two", "three"]
+    random.shuffle(regexes)
+    for key in regexes:
+        steps.load(key, func)
+    assert_equal([ item[0] for item in steps.items() ], regexes)
 
 def test_StepDict_can_extract_a_step_sentence_from_function_name():
     u"lettuce.STEP_REGISTRY._extract_sentence(func) parse func name and return a sentence"

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,6 @@ commands =
     pip install -q -r requirements.txt
     make unit functional
 whitelist_externals = make
+
+[testenv:py26]
+deps = ordereddict


### PR DESCRIPTION
see issue #464. dict.items() returns items in non-deterministic order.
for python 2.6 use `ordereddict.OrderedDict` and for python 2.7 use
`collections.OrderedDict`.
