### PR TITLE
Use Django 1.7 StaticLiveServerTestCase when available

### DIFF
--- a/lettuce/django/server.py
+++ b/lettuce/django/server.py
@@ -324,7 +324,11 @@ class DefaultServer(BaseServer):
 
 
 try:
-    from django.test.testcases import LiveServerTestCase
+    try:
+        from django.contrib.staticfiles.testing import \
+            StaticLiveServerTestCase as LiveServerTestCase
+    except ImportError:
+        from django.test.testcases import LiveServerTestCase
 
     class DjangoServer(BaseServer):
         """

--- a/lettuce/django/server.py
+++ b/lettuce/django/server.py
@@ -332,7 +332,7 @@ try:
 
     class DjangoServer(BaseServer):
         """
-        A sever that uses Django's LiveServerTestCase to implement the Server class.
+        A server that uses Django's LiveServerTestCase to implement the Server class.
         """
 
         _server = None


### PR DESCRIPTION
Lettuce DjangoServer uses LiveServerTestCase to implement his own server.

Django 1.7 changed the way LiveServerTestCase works and introduced the StaticLiveServerTestCase, to be used to hit static files in different places without run collectstatic:

https://docs.djangoproject.com/en/1.7/howto/static-files/#testing

Without it, it would be necessary to call collectstatic before run tests. I suggest to try import StaticLiveServerTestCase before LiveServerTestCase to match django 1.7.