### PR TITLE
fix language detection: detect language only in comments

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -41,7 +41,7 @@ class REP(object):
     "RegEx Pattern"
     first_of = re.compile(ur'^first_of_')
     last_of = re.compile(ur'^last_of_')
-    language = re.compile(u"language:[ ]*([^\s]+)")
+    language = re.compile(u"\s*#\s*language:[ ]*([^\s]+)")
     within_double_quotes = re.compile(r'("[^"]+")')
     within_single_quotes = re.compile(r"('[^']+')")
     only_whitespace = re.compile('^\s*$')

--- a/tests/unit/test_language.py
+++ b/tests/unit/test_language.py
@@ -35,3 +35,13 @@ def test_language_has_first_of():
 
     assert_equals(lang.first_of_examples, 'Examples')
 
+def test_search_language_only_in_comments():
+    assert_equals(Language.guess_from_string('#  language: fr').code, 'fr') 
+    assert_equals(Language.guess_from_string('#language: fr  ').code, 'fr') 
+    assert_equals(Language.guess_from_string('  #language:   fr').code, 'fr') 
+    assert_equals(Language.guess_from_string(' #   language: fr').code, 'fr') 
+    assert_equals(Language.guess_from_string('\t#   language: fr').code, 'fr') 
+    assert_equals(Language.guess_from_string('# language: fr foo').code, 'fr') 
+    
+    assert_equals(Language.guess_from_string('language: fr').code, 'en') 
+    assert_equals(Language.guess_from_string('#And my current language: fr').code, 'en') 


### PR DESCRIPTION
We have discovered a small bug in language detection.

```
Feature: Queue administration
  Scenario: CRUD
    Given: My language: fr
    ...
```
The language is switched to 'fr' whereas it should be 'en'

Mery christmas