### PR TITLE
Remove non-ASCII characters from a critical exception's message

### DIFF
--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -180,6 +180,9 @@ class Runner(object):
         except exceptions.LettuceSyntaxError, e:
             sys.stderr.write(e.msg)
             failed = True
+        except exceptions.NoDefinitionFound, e:
+            sys.stderr.write(e.msg)
+            failed = True
         except:
             if not self.failfast:
                 e = sys.exc_info()[1]

--- a/lettuce/exceptions.py
+++ b/lettuce/exceptions.py
@@ -28,8 +28,11 @@ class NoDefinitionFound(Exception):
     """
     def __init__(self, step):
         self.step = step
-        super(NoDefinitionFound, self).__init__(
-            'The step r"%s" is not defined' % self.step.sentence)
+
+        error = filter(lambda x : 0 <= ord(x) <= 127,
+                       'The step r"%s" is not defined' % self.step.sentence)
+        super(NoDefinitionFound, self).__init__(error)
+
 
 
 class ReasonToFail(object):


### PR DESCRIPTION
As explained in #478, when a step in the Background contains an non-ASCII character, the user is not warned.

I don't find any other convincing fix for this problem...