### PR TITLE
Fix the verbosity option conflict in Django 1.8

### DIFF
--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -22,6 +22,7 @@ release = 'kryptonite'
 import os
 import sys
 import traceback
+import warnings
 try:
     from imp import reload
 except ImportError:
@@ -122,9 +123,10 @@ class Runner(object):
         elif verbosity is 2:
             from lettuce.plugins import scenario_names as output
         elif verbosity is 3:
-            from lettuce.plugins import shell_output as output
-        else:
             from lettuce.plugins import colored_shell_output as output
+        else:
+            from lettuce.plugins import shell_output as output
+            warnings.warn('Deprecated in django 1.7 user -v 3 --no-color instead of the -v 4', DeprecationWarning)
 
         self.random = random
 

--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -89,7 +89,8 @@ class Runner(object):
     Takes a base path as parameter (string), so that it can look for
     features and step definitions on there.
     """
-    def __init__(self, base_path, scenarios=None, verbosity=0, random=False,
+    def __init__(self, base_path, scenarios=None,
+                 verbosity=0, use_color=True, random=False,
                  enable_xunit=False, xunit_filename=None,
                  enable_subunit=False, subunit_filename=None,
                  tags=None, failfast=False, auto_pdb=False,
@@ -122,11 +123,17 @@ class Runner(object):
             from lettuce.plugins import dots as output
         elif verbosity is 2:
             from lettuce.plugins import scenario_names as output
-        elif verbosity is 3:
-            from lettuce.plugins import colored_shell_output as output
         else:
-            from lettuce.plugins import shell_output as output
-            warnings.warn('Deprecated in django 1.7 user -v 3 --no-color instead of the -v 4', DeprecationWarning)
+            if verbosity is 4:
+                from lettuce.plugins import colored_shell_output as output
+                msg = ('Deprecated in lettuce 2.2.21. Use verbosity 3 combined'
+                       ' with --no-color flag instead of verbosity 4')
+                warnings.warn(msg, DeprecationWarning)
+            elif verbosity is 3:
+                if use_color:
+                    from lettuce.plugins import colored_shell_output as output
+                else:
+                    from lettuce.plugins import shell_output as output
 
         self.random = random
 

--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -90,7 +90,7 @@ class Runner(object):
     features and step definitions on there.
     """
     def __init__(self, base_path, scenarios=None,
-                 verbosity=0, use_color=True, random=False,
+                 verbosity=0, no_color=False, random=False,
                  enable_xunit=False, xunit_filename=None,
                  enable_subunit=False, subunit_filename=None,
                  tags=None, failfast=False, auto_pdb=False,
@@ -130,10 +130,10 @@ class Runner(object):
                        ' with --no-color flag instead of verbosity 4')
                 warnings.warn(msg, DeprecationWarning)
             elif verbosity is 3:
-                if use_color:
-                    from lettuce.plugins import colored_shell_output as output
-                else:
+                if no_color:
                     from lettuce.plugins import shell_output as output
+                else:
+                    from lettuce.plugins import colored_shell_output as output
 
         self.random = random
 

--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -126,8 +126,8 @@ class Runner(object):
         else:
             if verbosity is 4:
                 from lettuce.plugins import colored_shell_output as output
-                msg = ('Deprecated in lettuce 2.2.21. Use verbosity 3 combined'
-                       ' with --no-color flag instead of verbosity 4')
+                msg = ('Deprecated in lettuce 2.2.21. Use verbosity 3 without '
+                       '--no-color flag instead of verbosity 4')
                 warnings.warn(msg, DeprecationWarning)
             elif verbosity is 3:
                 if no_color:

--- a/lettuce/bin.py
+++ b/lettuce/bin.py
@@ -34,10 +34,10 @@ def main(args=sys.argv[1:]):
                       help='The verbosity level')
 
     parser.add_option("--no-color",
-                      action="store_false",
-                      dest="use_color",
-                      default=True,
-                      help='Prevent the output to be colored.')
+                      action="store_true",
+                      dest="no_color",
+                      default=False,
+                      help="Don't colorize the command output.")
 
     parser.add_option("-s", "--scenarios",
                       dest="scenarios",

--- a/lettuce/bin.py
+++ b/lettuce/bin.py
@@ -30,8 +30,14 @@ def main(args=sys.argv[1:]):
 
     parser.add_option("-v", "--verbosity",
                       dest="verbosity",
-                      default=4,
+                      default=3,
                       help='The verbosity level')
+
+    parser.add_option("--no-color",
+                      action="store_false",
+                      dest="use_color",
+                      default=True,
+                      help='Prevent the output to be colored.')
 
     parser.add_option("-s", "--scenarios",
                       dest="scenarios",

--- a/lettuce/django/management/commands/harvest.py
+++ b/lettuce/django/management/commands/harvest.py
@@ -120,10 +120,10 @@ class Command(BaseCommand):
             # Django 1.7 introduces the --no-color flag. We must add the flag
             # to be compatible with older django versions
             parser.add_option('--no-color',
-                              action='store_false',
-                              dest='use_color',
-                              default=True,
-                              help='Prevent the output to be colored.')
+                              action='store_true',
+                              dest='no_color',
+                              default=False,
+                              help="Don't colorize the command output.")
         return parser
 
     def stopserver(self, failed=False):
@@ -146,7 +146,7 @@ class Command(BaseCommand):
         setup_test_environment()
 
         verbosity = int(options.get('verbosity', 3))
-        use_color = int(options.get('use_color', True))
+        no_color = int(options.get('no_color', False))
         apps_to_run = tuple(options.get('apps', '').split(","))
         apps_to_avoid = tuple(options.get('avoid_apps', '').split(","))
         run_server = not options.get('no_server', False)
@@ -204,7 +204,7 @@ class Command(BaseCommand):
                     registry.call_hook('before_each', 'app', app_module)
 
                 runner = Runner(path, options.get('scenarios'),
-                                verbosity, use_color,
+                                verbosity, no_color,
                                 enable_xunit=options.get('enable_xunit'),
                                 enable_subunit=options.get('enable_subunit'),
                                 xunit_filename=options.get('xunit_file'),

--- a/lettuce/django/management/commands/harvest.py
+++ b/lettuce/django/management/commands/harvest.py
@@ -36,11 +36,7 @@ class Command(BaseCommand):
     args = '[PATH to feature file or folder]'
     requires_model_validation = False
 
-    option_list = BaseCommand.option_list[1:] + (
-        make_option('-v', '--verbosity', action='store', dest='verbosity', default='4',
-            type='choice', choices=map(str, range(5)),
-            help='Verbosity level; 0=no output, 1=only dots, 2=only scenario names, 3=colorless output, 4=normal output (colorful)'),
-
+    option_list = BaseCommand.option_list + (
         make_option('-a', '--apps', action='store', dest='apps', default='',
             help='Run ONLY the django apps that are listed here. Comma separated'),
 
@@ -49,7 +45,7 @@ class Command(BaseCommand):
 
         make_option('-S', '--no-server', action='store_true', dest='no_server', default=False,
             help="will not run django's builtin HTTP server"),
-            
+
         make_option('--nothreading', action='store_false', dest='use_threading', default=True,
             help='Tells Django to NOT use threading.'),
 
@@ -105,6 +101,16 @@ class Command(BaseCommand):
 
     )
 
+    def create_parser(self, prog_name, subcommand):
+        parser = super(Command, self).create_parser(prog_name, subcommand)
+        parser.remove_option('-v')
+        parser.add_option(
+            '-v', '--verbosity', action='store', dest='verbosity', default='3',
+            type='choice', choices=map(str, range(5)),
+            help='Verbosity level; 0=no output, 1=only dots, 2=only scenario names, 3=normal output (colorful), 4=colorless output (Deprecated)'
+        )
+        return parser
+
     def stopserver(self, failed=False):
         raise SystemExit(int(failed))
 
@@ -124,7 +130,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         setup_test_environment()
 
-        verbosity = int(options.get('verbosity', 4))
+        verbosity = int(options.get('verbosity', 3))
         apps_to_run = tuple(options.get('apps', '').split(","))
         apps_to_avoid = tuple(options.get('avoid_apps', '').split(","))
         run_server = not options.get('no_server', False)

--- a/tests/functional/language_specific_features/test_fr.py
+++ b/tests/functional/language_specific_features/test_fr.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: fr -> sucess colorless"
 
-    runner = Runner(join_path('fr', 'success', 'dumb.feature'), verbosity=3)
+    runner = Runner(join_path('fr', 'success', 'dumb.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -49,7 +49,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: fr -> sucess table colorless"
 
-    runner = Runner(join_path('fr', 'success', 'table.feature'), verbosity=3)
+    runner = Runner(join_path('fr', 'success', 'table.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -75,7 +75,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: fr -> sucess outlines colorless"
 
-    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -105,7 +105,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: fr -> sucess outlines colorful"
 
-    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(
@@ -134,7 +134,7 @@ def test_output_outlines_success_colorful():
 def test_output_outlines2_success_colorful():
     "Language: fr -> sucess outlines colorful, alternate name"
 
-    runner = Runner(join_path('fr', 'success', 'outlines2.feature'), verbosity=4)
+    runner = Runner(join_path('fr', 'success', 'outlines2.feature'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_fr.py
+++ b/tests/functional/language_specific_features/test_fr.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: fr -> sucess colorless"
 
-    runner = Runner(join_path('fr', 'success', 'dumb.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('fr', 'success', 'dumb.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -49,7 +49,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: fr -> sucess table colorless"
 
-    runner = Runner(join_path('fr', 'success', 'table.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('fr', 'success', 'table.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -75,7 +75,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: fr -> sucess outlines colorless"
 
-    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -105,7 +105,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: fr -> sucess outlines colorful"
 
-    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=3, use_color=True)
+    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -134,7 +134,7 @@ def test_output_outlines_success_colorful():
 def test_output_outlines2_success_colorful():
     "Language: fr -> sucess outlines colorful, alternate name"
 
-    runner = Runner(join_path('fr', 'success', 'outlines2.feature'), verbosity=3, use_color=True)
+    runner = Runner(join_path('fr', 'success', 'outlines2.feature'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_fr.py
+++ b/tests/functional/language_specific_features/test_fr.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: fr -> sucess colorless"
 
-    runner = Runner(join_path('fr', 'success', 'dumb.feature'), verbosity=4)
+    runner = Runner(join_path('fr', 'success', 'dumb.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -49,7 +49,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: fr -> sucess table colorless"
 
-    runner = Runner(join_path('fr', 'success', 'table.feature'), verbosity=4)
+    runner = Runner(join_path('fr', 'success', 'table.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -75,7 +75,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: fr -> sucess outlines colorless"
 
-    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -105,7 +105,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: fr -> sucess outlines colorful"
 
-    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('fr', 'success', 'outlines.feature'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -134,7 +134,7 @@ def test_output_outlines_success_colorful():
 def test_output_outlines2_success_colorful():
     "Language: fr -> sucess outlines colorful, alternate name"
 
-    runner = Runner(join_path('fr', 'success', 'outlines2.feature'), verbosity=3)
+    runner = Runner(join_path('fr', 'success', 'outlines2.feature'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_ja.py
+++ b/tests/functional/language_specific_features/test_ja.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: ja -> sucess colorless"
 
-    runner = Runner(join_path('ja', 'success', 'dumb.feature'), verbosity=4)
+    runner = Runner(join_path('ja', 'success', 'dumb.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -48,7 +48,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: ja -> sucess table colorless"
 
-    runner = Runner(join_path('ja', 'success', 'table.feature'), verbosity=4)
+    runner = Runner(join_path('ja', 'success', 'table.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -71,7 +71,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: ja -> sucess outlines colorless"
 
-    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -99,7 +99,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: ja -> sucess outlines colorful"
 
-    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_ja.py
+++ b/tests/functional/language_specific_features/test_ja.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: ja -> sucess colorless"
 
-    runner = Runner(join_path('ja', 'success', 'dumb.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('ja', 'success', 'dumb.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -48,7 +48,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: ja -> sucess table colorless"
 
-    runner = Runner(join_path('ja', 'success', 'table.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('ja', 'success', 'table.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -71,7 +71,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: ja -> sucess outlines colorless"
 
-    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -99,7 +99,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: ja -> sucess outlines colorful"
 
-    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=3, use_color=True)
+    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_ja.py
+++ b/tests/functional/language_specific_features/test_ja.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: ja -> sucess colorless"
 
-    runner = Runner(join_path('ja', 'success', 'dumb.feature'), verbosity=3)
+    runner = Runner(join_path('ja', 'success', 'dumb.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -48,7 +48,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: ja -> sucess table colorless"
 
-    runner = Runner(join_path('ja', 'success', 'table.feature'), verbosity=3)
+    runner = Runner(join_path('ja', 'success', 'table.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -71,7 +71,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: ja -> sucess outlines colorless"
 
-    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -99,7 +99,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: ja -> sucess outlines colorful"
 
-    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('ja', 'success', 'outlines.feature'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_ptbr.py
+++ b/tests/functional/language_specific_features/test_ptbr.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: pt-br -> sucess colorless"
 
-    runner = Runner(join_path('pt-br', 'success', 'dumb.feature'), verbosity=3)
+    runner = Runner(join_path('pt-br', 'success', 'dumb.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -50,7 +50,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: pt-br -> sucess table colorless"
 
-    runner = Runner(join_path('pt-br', 'success', 'table.feature'), verbosity=3)
+    runner = Runner(join_path('pt-br', 'success', 'table.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -75,7 +75,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: pt-br -> sucess outlines colorless"
 
-    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -105,7 +105,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: pt-br -> sucess outlines colorful"
 
-    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_ptbr.py
+++ b/tests/functional/language_specific_features/test_ptbr.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: pt-br -> sucess colorless"
 
-    runner = Runner(join_path('pt-br', 'success', 'dumb.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('pt-br', 'success', 'dumb.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -50,7 +50,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: pt-br -> sucess table colorless"
 
-    runner = Runner(join_path('pt-br', 'success', 'table.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('pt-br', 'success', 'table.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -75,7 +75,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: pt-br -> sucess outlines colorless"
 
-    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -105,7 +105,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: pt-br -> sucess outlines colorful"
 
-    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=3, use_color=True)
+    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_ptbr.py
+++ b/tests/functional/language_specific_features/test_ptbr.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: pt-br -> sucess colorless"
 
-    runner = Runner(join_path('pt-br', 'success', 'dumb.feature'), verbosity=4)
+    runner = Runner(join_path('pt-br', 'success', 'dumb.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -50,7 +50,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: pt-br -> sucess table colorless"
 
-    runner = Runner(join_path('pt-br', 'success', 'table.feature'), verbosity=4)
+    runner = Runner(join_path('pt-br', 'success', 'table.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -75,7 +75,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: pt-br -> sucess outlines colorless"
 
-    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -105,7 +105,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: pt-br -> sucess outlines colorful"
 
-    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('pt-br', 'success', 'outlines.feature'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_ru.py
+++ b/tests/functional/language_specific_features/test_ru.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: ru -> sucess colorless"
 
-    runner = Runner(join_path('ru', 'success', 'dumb.feature'), verbosity=4)
+    runner = Runner(join_path('ru', 'success', 'dumb.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -51,7 +51,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: ru -> sucess table colorless"
 
-    runner = Runner(join_path('ru', 'success', 'table.feature'), verbosity=4)
+    runner = Runner(join_path('ru', 'success', 'table.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -76,7 +76,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: ru -> sucess outlines colorless"
 
-    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -108,7 +108,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: ru -> sucess outlines colorful"
 
-    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_ru.py
+++ b/tests/functional/language_specific_features/test_ru.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: ru -> sucess colorless"
 
-    runner = Runner(join_path('ru', 'success', 'dumb.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('ru', 'success', 'dumb.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -51,7 +51,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: ru -> sucess table colorless"
 
-    runner = Runner(join_path('ru', 'success', 'table.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('ru', 'success', 'table.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -76,7 +76,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: ru -> sucess outlines colorless"
 
-    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -108,7 +108,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: ru -> sucess outlines colorful"
 
-    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=3, use_color=True)
+    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_ru.py
+++ b/tests/functional/language_specific_features/test_ru.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: ru -> sucess colorless"
 
-    runner = Runner(join_path('ru', 'success', 'dumb.feature'), verbosity=3)
+    runner = Runner(join_path('ru', 'success', 'dumb.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -51,7 +51,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: ru -> sucess table colorless"
 
-    runner = Runner(join_path('ru', 'success', 'table.feature'), verbosity=3)
+    runner = Runner(join_path('ru', 'success', 'table.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -76,7 +76,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: ru -> sucess outlines colorless"
 
-    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -108,7 +108,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: ru -> sucess outlines colorful"
 
-    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('ru', 'success', 'outlines.feature'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_zh-CN.py
+++ b/tests/functional/language_specific_features/test_zh-CN.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: zh-CN -> sucess colorless"
 
-    runner = Runner(join_path('zh-CN', 'success', 'dumb.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('zh-CN', 'success', 'dumb.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -48,7 +48,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: zh-CN -> sucess table colorless"
 
-    runner = Runner(join_path('zh-CN', 'success', 'table.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('zh-CN', 'success', 'table.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -71,7 +71,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: zh-CN -> sucess outlines colorless"
 
-    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -99,7 +99,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: zh-CN -> sucess outlines colorful"
 
-    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=3, use_color=True)
+    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_zh-CN.py
+++ b/tests/functional/language_specific_features/test_zh-CN.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: zh-CN -> sucess colorless"
 
-    runner = Runner(join_path('zh-CN', 'success', 'dumb.feature'), verbosity=3)
+    runner = Runner(join_path('zh-CN', 'success', 'dumb.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -48,7 +48,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: zh-CN -> sucess table colorless"
 
-    runner = Runner(join_path('zh-CN', 'success', 'table.feature'), verbosity=3)
+    runner = Runner(join_path('zh-CN', 'success', 'table.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -71,7 +71,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: zh-CN -> sucess outlines colorless"
 
-    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -99,7 +99,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: zh-CN -> sucess outlines colorful"
 
-    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_zh-CN.py
+++ b/tests/functional/language_specific_features/test_zh-CN.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: zh-CN -> sucess colorless"
 
-    runner = Runner(join_path('zh-CN', 'success', 'dumb.feature'), verbosity=4)
+    runner = Runner(join_path('zh-CN', 'success', 'dumb.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -48,7 +48,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: zh-CN -> sucess table colorless"
 
-    runner = Runner(join_path('zh-CN', 'success', 'table.feature'), verbosity=4)
+    runner = Runner(join_path('zh-CN', 'success', 'table.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -71,7 +71,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: zh-CN -> sucess outlines colorless"
 
-    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -99,7 +99,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: zh-CN -> sucess outlines colorful"
 
-    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('zh-CN', 'success', 'outlines.feature'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_zh-TW.py
+++ b/tests/functional/language_specific_features/test_zh-TW.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: zh-TW -> sucess colorless"
 
-    runner = Runner(join_path('zh-TW', 'success', 'dumb.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('zh-TW', 'success', 'dumb.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -48,7 +48,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: zh-TW -> sucess table colorless"
 
-    runner = Runner(join_path('zh-TW', 'success', 'table.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('zh-TW', 'success', 'table.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -71,7 +71,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: zh-TW -> sucess outlines colorless"
 
-    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=3, use_color=False)
+    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -99,7 +99,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: zh-TW -> sucess outlines colorful"
 
-    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=3, use_color=True)
+    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_zh-TW.py
+++ b/tests/functional/language_specific_features/test_zh-TW.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: zh-TW -> sucess colorless"
 
-    runner = Runner(join_path('zh-TW', 'success', 'dumb.feature'), verbosity=4)
+    runner = Runner(join_path('zh-TW', 'success', 'dumb.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -48,7 +48,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: zh-TW -> sucess table colorless"
 
-    runner = Runner(join_path('zh-TW', 'success', 'table.feature'), verbosity=4)
+    runner = Runner(join_path('zh-TW', 'success', 'table.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -71,7 +71,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: zh-TW -> sucess outlines colorless"
 
-    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -99,7 +99,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: zh-TW -> sucess outlines colorful"
 
-    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/language_specific_features/test_zh-TW.py
+++ b/tests/functional/language_specific_features/test_zh-TW.py
@@ -28,7 +28,7 @@ join_path = lambda *x: join(current_dir, *x)
 def test_output_with_success_colorless():
     "Language: zh-TW -> sucess colorless"
 
-    runner = Runner(join_path('zh-TW', 'success', 'dumb.feature'), verbosity=3)
+    runner = Runner(join_path('zh-TW', 'success', 'dumb.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -48,7 +48,7 @@ def test_output_with_success_colorless():
 def test_output_of_table_with_success_colorless():
     "Language: zh-TW -> sucess table colorless"
 
-    runner = Runner(join_path('zh-TW', 'success', 'table.feature'), verbosity=3)
+    runner = Runner(join_path('zh-TW', 'success', 'table.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -71,7 +71,7 @@ def test_output_of_table_with_success_colorless():
 def test_output_outlines_success_colorless():
     "Language: zh-TW -> sucess outlines colorless"
 
-    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=3)
+    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -99,7 +99,7 @@ def test_output_outlines_success_colorless():
 def test_output_outlines_success_colorful():
     "Language: zh-TW -> sucess outlines colorful"
 
-    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=4)
+    runner = Runner(join_path('zh-TW', 'success', 'outlines.feature'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(

--- a/tests/functional/test_behave_as_handling.py
+++ b/tests/functional/test_behave_as_handling.py
@@ -37,7 +37,7 @@ def path_to_feature(name):
 @with_setup(prepare_stdout)
 def test_simple_behave_as_feature():
     "Basic step.behave_as behaviour is working"
-    Runner(path_to_feature('1st_normal_steps'), verbosity=3).run()
+    Runner(path_to_feature('1st_normal_steps'), verbosity=4).run()
     assert_stdout_lines(
         "\n"
         "Feature: Multiplication                            # tests/functional/behave_as_features/1st_normal_steps/1st_normal_steps.feature:2\n"
@@ -62,7 +62,7 @@ def test_simple_behave_as_feature():
 @with_setup(prepare_stdout)
 def test_simple_tables_behave_as_feature():
     "Basic step.behave_as behaviour is working"
-    Runner(path_to_feature('2nd_table_steps'), verbosity=3).run()
+    Runner(path_to_feature('2nd_table_steps'), verbosity=4).run()
     assert_stdout_lines(
         "\n"
         "Feature: Multiplication                            # tests/functional/behave_as_features/2nd_table_steps/2nd_table_steps.feature:2\n"
@@ -88,7 +88,7 @@ def test_simple_tables_behave_as_feature():
 @with_setup(prepare_stdout)
 def test_failing_tables_behave_as_feature():
     "Basic step.behave_as behaviour is working"
-    Runner(path_to_feature('3rd_failing_steps'), verbosity=3).run()
+    Runner(path_to_feature('3rd_failing_steps'), verbosity=4).run()
     assert_stdout_lines_with_traceback(
     '\n'
     'Feature: Multiplication                            # tests/functional/behave_as_features/3rd_failing_steps/3rd_failing_steps.feature:2\n'

--- a/tests/functional/test_behave_as_handling.py
+++ b/tests/functional/test_behave_as_handling.py
@@ -37,7 +37,7 @@ def path_to_feature(name):
 @with_setup(prepare_stdout)
 def test_simple_behave_as_feature():
     "Basic step.behave_as behaviour is working"
-    Runner(path_to_feature('1st_normal_steps'), verbosity=4).run()
+    Runner(path_to_feature('1st_normal_steps'), verbosity=3, use_color=False).run()
     assert_stdout_lines(
         "\n"
         "Feature: Multiplication                            # tests/functional/behave_as_features/1st_normal_steps/1st_normal_steps.feature:2\n"
@@ -62,7 +62,7 @@ def test_simple_behave_as_feature():
 @with_setup(prepare_stdout)
 def test_simple_tables_behave_as_feature():
     "Basic step.behave_as behaviour is working"
-    Runner(path_to_feature('2nd_table_steps'), verbosity=4).run()
+    Runner(path_to_feature('2nd_table_steps'), verbosity=3, use_color=False).run()
     assert_stdout_lines(
         "\n"
         "Feature: Multiplication                            # tests/functional/behave_as_features/2nd_table_steps/2nd_table_steps.feature:2\n"
@@ -88,7 +88,7 @@ def test_simple_tables_behave_as_feature():
 @with_setup(prepare_stdout)
 def test_failing_tables_behave_as_feature():
     "Basic step.behave_as behaviour is working"
-    Runner(path_to_feature('3rd_failing_steps'), verbosity=4).run()
+    Runner(path_to_feature('3rd_failing_steps'), verbosity=3, use_color=False).run()
     assert_stdout_lines_with_traceback(
     '\n'
     'Feature: Multiplication                            # tests/functional/behave_as_features/3rd_failing_steps/3rd_failing_steps.feature:2\n'

--- a/tests/functional/test_behave_as_handling.py
+++ b/tests/functional/test_behave_as_handling.py
@@ -37,7 +37,7 @@ def path_to_feature(name):
 @with_setup(prepare_stdout)
 def test_simple_behave_as_feature():
     "Basic step.behave_as behaviour is working"
-    Runner(path_to_feature('1st_normal_steps'), verbosity=3, use_color=False).run()
+    Runner(path_to_feature('1st_normal_steps'), verbosity=3, no_color=True).run()
     assert_stdout_lines(
         "\n"
         "Feature: Multiplication                            # tests/functional/behave_as_features/1st_normal_steps/1st_normal_steps.feature:2\n"
@@ -62,7 +62,7 @@ def test_simple_behave_as_feature():
 @with_setup(prepare_stdout)
 def test_simple_tables_behave_as_feature():
     "Basic step.behave_as behaviour is working"
-    Runner(path_to_feature('2nd_table_steps'), verbosity=3, use_color=False).run()
+    Runner(path_to_feature('2nd_table_steps'), verbosity=3, no_color=True).run()
     assert_stdout_lines(
         "\n"
         "Feature: Multiplication                            # tests/functional/behave_as_features/2nd_table_steps/2nd_table_steps.feature:2\n"
@@ -88,7 +88,7 @@ def test_simple_tables_behave_as_feature():
 @with_setup(prepare_stdout)
 def test_failing_tables_behave_as_feature():
     "Basic step.behave_as behaviour is working"
-    Runner(path_to_feature('3rd_failing_steps'), verbosity=3, use_color=False).run()
+    Runner(path_to_feature('3rd_failing_steps'), verbosity=3, no_color=True).run()
     assert_stdout_lines_with_traceback(
     '\n'
     'Feature: Multiplication                            # tests/functional/behave_as_features/3rd_failing_steps/3rd_failing_steps.feature:2\n'

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -170,7 +170,7 @@ def test_defined_step_represent_string():
 def test_output_with_success_colorless2():
     "Testing the colorless output of a successful feature"
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=3, use_color=False)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -193,7 +193,7 @@ def test_output_with_success_colorless2():
 def test_output_with_success_colorless():
     "A feature with two scenarios should separate the two scenarios with a new line (in colorless mode)."
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=3, use_color=False)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -219,7 +219,7 @@ def test_output_with_success_colorless():
 def test_output_with_success_colorful():
     "Testing the output of a successful feature"
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=3, use_color=True)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -243,7 +243,7 @@ def test_output_with_success_colorful():
 def test_output_with_success_colorful_newline():
     "A feature with two scenarios should separate the two scenarios with a new line (in color mode)."
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=3, use_color=True)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -270,7 +270,7 @@ def test_output_with_success_colorful_newline():
 @with_setup(prepare_stdout)
 def test_output_with_success_colorless_many_features():
     "Testing the output of many successful features"
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=3, use_color=False)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -301,7 +301,7 @@ def test_output_with_success_colorless_many_features():
 def test_output_with_success_colorful_many_features():
     "Testing the colorful output of many successful features"
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=3, use_color=True)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -337,7 +337,7 @@ def test_output_when_could_not_find_features():
     "Testing the colorful output of many successful features"
 
     path = fs.relpath(join(abspath(dirname(__file__)), 'no_features', 'unexistent-folder'))
-    runner = Runner(path, verbosity=3, use_color=True)
+    runner = Runner(path, verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -351,7 +351,7 @@ def test_output_when_could_not_find_features_colorless():
     "Testing the colorful output of many successful features colorless"
 
     path = fs.relpath(join(abspath(dirname(__file__)), 'no_features', 'unexistent-folder'))
-    runner = Runner(path, verbosity=3, use_color=False)
+    runner = Runner(path, verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -378,7 +378,7 @@ def test_output_when_could_not_find_features_verbosity_level_2():
 def test_output_with_success_colorless_with_table():
     "Testing the colorless output of success with table"
 
-    runner = Runner(feature_name('success_table'), verbosity=3, use_color=False)
+    runner = Runner(feature_name('success_table'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -407,7 +407,7 @@ def test_output_with_success_colorless_with_table():
 def test_output_with_success_colorful_with_table():
     "Testing the colorful output of success with table"
 
-    runner = Runner(feature_name('success_table'), verbosity=3, use_color=True)
+    runner = Runner(feature_name('success_table'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -446,7 +446,7 @@ def test_output_with_success_colorful_with_table():
 def test_output_with_failed_colorless_with_table():
     "Testing the colorless output of failed with table"
 
-    runner = Runner(feature_name('failed_table'), verbosity=3, use_color=False)
+    runner = Runner(feature_name('failed_table'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -493,7 +493,7 @@ def test_output_with_failed_colorless_with_table():
 def test_output_with_failed_colorful_with_table():
     "Testing the colorful output of failed with table"
 
-    runner = Runner(feature_name('failed_table'), verbosity=3, use_color=True)
+    runner = Runner(feature_name('failed_table'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -545,7 +545,7 @@ def test_output_with_failed_colorful_with_table():
 def test_output_with_successful_outline_colorless():
     "With colorless output, a successful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('success_outline'), verbosity=3, use_color=False)
+    runner = Runner(feature_name('success_outline'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -581,7 +581,7 @@ def test_output_with_successful_outline_colorless():
 def test_output_with_successful_outline_colorful():
     "With colored output, a successful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('success_outline'), verbosity=3, use_color=True)
+    runner = Runner(feature_name('success_outline'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -617,7 +617,7 @@ def test_output_with_successful_outline_colorful():
 def test_output_with_failful_outline_colorless():
     "With colorless output, an unsuccessful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('fail_outline'), verbosity=3, use_color=False)
+    runner = Runner(feature_name('fail_outline'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -667,7 +667,7 @@ def test_output_with_failful_outline_colorless():
 def test_output_with_failful_outline_colorful():
     "With colored output, an unsuccessful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('fail_outline'), verbosity=3, use_color=True)
+    runner = Runner(feature_name('fail_outline'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -717,7 +717,7 @@ def test_output_with_failful_outline_colorful():
 def test_output_snippets_with_groups_within_double_quotes_colorless():
     "Testing that the proposed snippet is clever enough to identify groups within double quotes. colorless"
 
-    runner = Runner(feature_name('double-quoted-snippet'), verbosity=3, use_color=False)
+    runner = Runner(feature_name('double-quoted-snippet'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -746,7 +746,7 @@ def test_output_snippets_with_groups_within_double_quotes_colorless():
 def test_output_snippets_with_groups_within_double_quotes_colorful():
     "Testing that the proposed snippet is clever enough to identify groups within double quotes. colorful"
 
-    runner = Runner(feature_name('double-quoted-snippet'), verbosity=3, use_color=True)
+    runner = Runner(feature_name('double-quoted-snippet'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -775,7 +775,7 @@ def test_output_snippets_with_groups_within_double_quotes_colorful():
 def test_output_snippets_with_groups_within_single_quotes_colorless():
     "Testing that the proposed snippet is clever enough to identify groups within single quotes. colorless"
 
-    runner = Runner(feature_name('single-quoted-snippet'), verbosity=3, use_color=False)
+    runner = Runner(feature_name('single-quoted-snippet'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -804,7 +804,7 @@ def test_output_snippets_with_groups_within_single_quotes_colorless():
 def test_output_snippets_with_groups_within_single_quotes_colorful():
     "Testing that the proposed snippet is clever enough to identify groups within single quotes. colorful"
 
-    runner = Runner(feature_name('single-quoted-snippet'), verbosity=3, use_color=True)
+    runner = Runner(feature_name('single-quoted-snippet'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -833,7 +833,7 @@ def test_output_snippets_with_groups_within_single_quotes_colorful():
 def test_output_snippets_with_groups_within_redundant_quotes():
     "Testing that the proposed snippet is clever enough to avoid duplicating the same snippet"
 
-    runner = Runner(feature_name('redundant-steps-quotes'), verbosity=3, use_color=False)
+    runner = Runner(feature_name('redundant-steps-quotes'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -863,7 +863,7 @@ def test_output_snippets_with_groups_within_redundant_quotes():
 def test_output_snippets_with_normalized_unicode_names():
     "Testing that the proposed snippet is clever enough normalize method names even with latin accents"
 
-    runner = Runner(feature_name('latin-accents'), verbosity=3, use_color=False)
+    runner = Runner(feature_name('latin-accents'), verbosity=3, no_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -1260,7 +1260,7 @@ def test_output_background_with_success_colorless():
         pass
 
     filename = bg_feature_name('simple')
-    runner = Runner(filename, verbosity=3, use_color=False)
+    runner = Runner(filename, verbosity=3, no_color=True)
 
     runner.run()
 
@@ -1297,7 +1297,7 @@ def test_output_background_with_success_colorful():
         pass
 
     filename = bg_feature_name('simple')
-    runner = Runner(filename, verbosity=3, use_color=True)
+    runner = Runner(filename, verbosity=3, no_color=False)
 
     runner.run()
 
@@ -1410,7 +1410,7 @@ def test_feature_missing_scenarios():
 def test_output_with_undefined_steps_colorful():
     "With colored output, an undefined step should be printed in sequence."
 
-    runner = Runner(feature_name('undefined_steps'), verbosity=3, use_color=True)
+    runner = Runner(feature_name('undefined_steps'), verbosity=3, no_color=False)
     runner.run()
 
     assert_stdout_lines_with_traceback(

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -170,7 +170,7 @@ def test_defined_step_represent_string():
 def test_output_with_success_colorless2():
     "Testing the colorless output of a successful feature"
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=3)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -193,7 +193,7 @@ def test_output_with_success_colorless2():
 def test_output_with_success_colorless():
     "A feature with two scenarios should separate the two scenarios with a new line (in colorless mode)."
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=3)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -219,7 +219,7 @@ def test_output_with_success_colorless():
 def test_output_with_success_colorful():
     "Testing the output of a successful feature"
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=4)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(
@@ -243,7 +243,7 @@ def test_output_with_success_colorful():
 def test_output_with_success_colorful_newline():
     "A feature with two scenarios should separate the two scenarios with a new line (in color mode)."
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=4)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(
@@ -270,7 +270,7 @@ def test_output_with_success_colorful_newline():
 @with_setup(prepare_stdout)
 def test_output_with_success_colorless_many_features():
     "Testing the output of many successful features"
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=3)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -301,7 +301,7 @@ def test_output_with_success_colorless_many_features():
 def test_output_with_success_colorful_many_features():
     "Testing the colorful output of many successful features"
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=4)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(
@@ -337,7 +337,7 @@ def test_output_when_could_not_find_features():
     "Testing the colorful output of many successful features"
 
     path = fs.relpath(join(abspath(dirname(__file__)), 'no_features', 'unexistent-folder'))
-    runner = Runner(path, verbosity=4)
+    runner = Runner(path, verbosity=3)
     runner.run()
 
     assert_stdout_lines(
@@ -351,7 +351,7 @@ def test_output_when_could_not_find_features_colorless():
     "Testing the colorful output of many successful features colorless"
 
     path = fs.relpath(join(abspath(dirname(__file__)), 'no_features', 'unexistent-folder'))
-    runner = Runner(path, verbosity=3)
+    runner = Runner(path, verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -378,7 +378,7 @@ def test_output_when_could_not_find_features_verbosity_level_2():
 def test_output_with_success_colorless_with_table():
     "Testing the colorless output of success with table"
 
-    runner = Runner(feature_name('success_table'), verbosity=3)
+    runner = Runner(feature_name('success_table'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -407,7 +407,7 @@ def test_output_with_success_colorless_with_table():
 def test_output_with_success_colorful_with_table():
     "Testing the colorful output of success with table"
 
-    runner = Runner(feature_name('success_table'), verbosity=4)
+    runner = Runner(feature_name('success_table'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(
@@ -446,7 +446,7 @@ def test_output_with_success_colorful_with_table():
 def test_output_with_failed_colorless_with_table():
     "Testing the colorless output of failed with table"
 
-    runner = Runner(feature_name('failed_table'), verbosity=3)
+    runner = Runner(feature_name('failed_table'), verbosity=4)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -493,7 +493,7 @@ def test_output_with_failed_colorless_with_table():
 def test_output_with_failed_colorful_with_table():
     "Testing the colorful output of failed with table"
 
-    runner = Runner(feature_name('failed_table'), verbosity=4)
+    runner = Runner(feature_name('failed_table'), verbosity=3)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -545,7 +545,7 @@ def test_output_with_failed_colorful_with_table():
 def test_output_with_successful_outline_colorless():
     "With colorless output, a successful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('success_outline'), verbosity=3)
+    runner = Runner(feature_name('success_outline'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -581,7 +581,7 @@ def test_output_with_successful_outline_colorless():
 def test_output_with_successful_outline_colorful():
     "With colored output, a successful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('success_outline'), verbosity=4)
+    runner = Runner(feature_name('success_outline'), verbosity=3)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -617,7 +617,7 @@ def test_output_with_successful_outline_colorful():
 def test_output_with_failful_outline_colorless():
     "With colorless output, an unsuccessful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('fail_outline'), verbosity=3)
+    runner = Runner(feature_name('fail_outline'), verbosity=4)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -667,7 +667,7 @@ def test_output_with_failful_outline_colorless():
 def test_output_with_failful_outline_colorful():
     "With colored output, an unsuccessful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('fail_outline'), verbosity=4)
+    runner = Runner(feature_name('fail_outline'), verbosity=3)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -717,7 +717,7 @@ def test_output_with_failful_outline_colorful():
 def test_output_snippets_with_groups_within_double_quotes_colorless():
     "Testing that the proposed snippet is clever enough to identify groups within double quotes. colorless"
 
-    runner = Runner(feature_name('double-quoted-snippet'), verbosity=3)
+    runner = Runner(feature_name('double-quoted-snippet'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -746,7 +746,7 @@ def test_output_snippets_with_groups_within_double_quotes_colorless():
 def test_output_snippets_with_groups_within_double_quotes_colorful():
     "Testing that the proposed snippet is clever enough to identify groups within double quotes. colorful"
 
-    runner = Runner(feature_name('double-quoted-snippet'), verbosity=4)
+    runner = Runner(feature_name('double-quoted-snippet'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(
@@ -775,7 +775,7 @@ def test_output_snippets_with_groups_within_double_quotes_colorful():
 def test_output_snippets_with_groups_within_single_quotes_colorless():
     "Testing that the proposed snippet is clever enough to identify groups within single quotes. colorless"
 
-    runner = Runner(feature_name('single-quoted-snippet'), verbosity=3)
+    runner = Runner(feature_name('single-quoted-snippet'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -804,7 +804,7 @@ def test_output_snippets_with_groups_within_single_quotes_colorless():
 def test_output_snippets_with_groups_within_single_quotes_colorful():
     "Testing that the proposed snippet is clever enough to identify groups within single quotes. colorful"
 
-    runner = Runner(feature_name('single-quoted-snippet'), verbosity=4)
+    runner = Runner(feature_name('single-quoted-snippet'), verbosity=3)
     runner.run()
 
     assert_stdout_lines(
@@ -833,7 +833,7 @@ def test_output_snippets_with_groups_within_single_quotes_colorful():
 def test_output_snippets_with_groups_within_redundant_quotes():
     "Testing that the proposed snippet is clever enough to avoid duplicating the same snippet"
 
-    runner = Runner(feature_name('redundant-steps-quotes'), verbosity=3)
+    runner = Runner(feature_name('redundant-steps-quotes'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -863,7 +863,7 @@ def test_output_snippets_with_groups_within_redundant_quotes():
 def test_output_snippets_with_normalized_unicode_names():
     "Testing that the proposed snippet is clever enough normalize method names even with latin accents"
 
-    runner = Runner(feature_name('latin-accents'), verbosity=3)
+    runner = Runner(feature_name('latin-accents'), verbosity=4)
     runner.run()
 
     assert_stdout_lines(
@@ -1260,7 +1260,7 @@ def test_output_background_with_success_colorless():
         pass
 
     filename = bg_feature_name('simple')
-    runner = Runner(filename, verbosity=3)
+    runner = Runner(filename, verbosity=4)
 
     runner.run()
 
@@ -1286,7 +1286,7 @@ def test_output_background_with_success_colorless():
 
 @with_setup(prepare_stdout)
 def test_output_background_with_success_colorful():
-    "A feature with background should print it accordingly under verbosity 4"
+    "A feature with background should print it accordingly under verbosity 3"
 
     from lettuce import step
 
@@ -1297,7 +1297,7 @@ def test_output_background_with_success_colorful():
         pass
 
     filename = bg_feature_name('simple')
-    runner = Runner(filename, verbosity=4)
+    runner = Runner(filename, verbosity=3)
 
     runner.run()
 
@@ -1410,7 +1410,7 @@ def test_feature_missing_scenarios():
 def test_output_with_undefined_steps_colorful():
     "With colored output, an undefined step should be printed in sequence."
 
-    runner = Runner(feature_name('undefined_steps'), verbosity=4)
+    runner = Runner(feature_name('undefined_steps'), verbosity=3)
     runner.run()
 
     assert_stdout_lines_with_traceback(

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -170,7 +170,7 @@ def test_defined_step_represent_string():
 def test_output_with_success_colorless2():
     "Testing the colorless output of a successful feature"
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=4)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -193,7 +193,7 @@ def test_output_with_success_colorless2():
 def test_output_with_success_colorless():
     "A feature with two scenarios should separate the two scenarios with a new line (in colorless mode)."
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=4)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -219,7 +219,7 @@ def test_output_with_success_colorless():
 def test_output_with_success_colorful():
     "Testing the output of a successful feature"
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=3)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'runner_features'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -243,7 +243,7 @@ def test_output_with_success_colorful():
 def test_output_with_success_colorful_newline():
     "A feature with two scenarios should separate the two scenarios with a new line (in color mode)."
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=3)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_scenarios'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -270,7 +270,7 @@ def test_output_with_success_colorful_newline():
 @with_setup(prepare_stdout)
 def test_output_with_success_colorless_many_features():
     "Testing the output of many successful features"
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=4)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -301,7 +301,7 @@ def test_output_with_success_colorless_many_features():
 def test_output_with_success_colorful_many_features():
     "Testing the colorful output of many successful features"
 
-    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=3)
+    runner = Runner(join(abspath(dirname(__file__)), 'output_features', 'many_successful_features'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -337,7 +337,7 @@ def test_output_when_could_not_find_features():
     "Testing the colorful output of many successful features"
 
     path = fs.relpath(join(abspath(dirname(__file__)), 'no_features', 'unexistent-folder'))
-    runner = Runner(path, verbosity=3)
+    runner = Runner(path, verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -351,7 +351,7 @@ def test_output_when_could_not_find_features_colorless():
     "Testing the colorful output of many successful features colorless"
 
     path = fs.relpath(join(abspath(dirname(__file__)), 'no_features', 'unexistent-folder'))
-    runner = Runner(path, verbosity=4)
+    runner = Runner(path, verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -378,7 +378,7 @@ def test_output_when_could_not_find_features_verbosity_level_2():
 def test_output_with_success_colorless_with_table():
     "Testing the colorless output of success with table"
 
-    runner = Runner(feature_name('success_table'), verbosity=4)
+    runner = Runner(feature_name('success_table'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -407,7 +407,7 @@ def test_output_with_success_colorless_with_table():
 def test_output_with_success_colorful_with_table():
     "Testing the colorful output of success with table"
 
-    runner = Runner(feature_name('success_table'), verbosity=3)
+    runner = Runner(feature_name('success_table'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -446,7 +446,7 @@ def test_output_with_success_colorful_with_table():
 def test_output_with_failed_colorless_with_table():
     "Testing the colorless output of failed with table"
 
-    runner = Runner(feature_name('failed_table'), verbosity=4)
+    runner = Runner(feature_name('failed_table'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -493,7 +493,7 @@ def test_output_with_failed_colorless_with_table():
 def test_output_with_failed_colorful_with_table():
     "Testing the colorful output of failed with table"
 
-    runner = Runner(feature_name('failed_table'), verbosity=3)
+    runner = Runner(feature_name('failed_table'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -545,7 +545,7 @@ def test_output_with_failed_colorful_with_table():
 def test_output_with_successful_outline_colorless():
     "With colorless output, a successful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('success_outline'), verbosity=4)
+    runner = Runner(feature_name('success_outline'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -581,7 +581,7 @@ def test_output_with_successful_outline_colorless():
 def test_output_with_successful_outline_colorful():
     "With colored output, a successful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('success_outline'), verbosity=3)
+    runner = Runner(feature_name('success_outline'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -617,7 +617,7 @@ def test_output_with_successful_outline_colorful():
 def test_output_with_failful_outline_colorless():
     "With colorless output, an unsuccessful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('fail_outline'), verbosity=4)
+    runner = Runner(feature_name('fail_outline'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -667,7 +667,7 @@ def test_output_with_failful_outline_colorless():
 def test_output_with_failful_outline_colorful():
     "With colored output, an unsuccessful outline scenario should print beautifully."
 
-    runner = Runner(feature_name('fail_outline'), verbosity=3)
+    runner = Runner(feature_name('fail_outline'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines_with_traceback(
@@ -717,7 +717,7 @@ def test_output_with_failful_outline_colorful():
 def test_output_snippets_with_groups_within_double_quotes_colorless():
     "Testing that the proposed snippet is clever enough to identify groups within double quotes. colorless"
 
-    runner = Runner(feature_name('double-quoted-snippet'), verbosity=4)
+    runner = Runner(feature_name('double-quoted-snippet'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -746,7 +746,7 @@ def test_output_snippets_with_groups_within_double_quotes_colorless():
 def test_output_snippets_with_groups_within_double_quotes_colorful():
     "Testing that the proposed snippet is clever enough to identify groups within double quotes. colorful"
 
-    runner = Runner(feature_name('double-quoted-snippet'), verbosity=3)
+    runner = Runner(feature_name('double-quoted-snippet'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -775,7 +775,7 @@ def test_output_snippets_with_groups_within_double_quotes_colorful():
 def test_output_snippets_with_groups_within_single_quotes_colorless():
     "Testing that the proposed snippet is clever enough to identify groups within single quotes. colorless"
 
-    runner = Runner(feature_name('single-quoted-snippet'), verbosity=4)
+    runner = Runner(feature_name('single-quoted-snippet'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -804,7 +804,7 @@ def test_output_snippets_with_groups_within_single_quotes_colorless():
 def test_output_snippets_with_groups_within_single_quotes_colorful():
     "Testing that the proposed snippet is clever enough to identify groups within single quotes. colorful"
 
-    runner = Runner(feature_name('single-quoted-snippet'), verbosity=3)
+    runner = Runner(feature_name('single-quoted-snippet'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines(
@@ -833,7 +833,7 @@ def test_output_snippets_with_groups_within_single_quotes_colorful():
 def test_output_snippets_with_groups_within_redundant_quotes():
     "Testing that the proposed snippet is clever enough to avoid duplicating the same snippet"
 
-    runner = Runner(feature_name('redundant-steps-quotes'), verbosity=4)
+    runner = Runner(feature_name('redundant-steps-quotes'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -863,7 +863,7 @@ def test_output_snippets_with_groups_within_redundant_quotes():
 def test_output_snippets_with_normalized_unicode_names():
     "Testing that the proposed snippet is clever enough normalize method names even with latin accents"
 
-    runner = Runner(feature_name('latin-accents'), verbosity=4)
+    runner = Runner(feature_name('latin-accents'), verbosity=3, use_color=False)
     runner.run()
 
     assert_stdout_lines(
@@ -1260,7 +1260,7 @@ def test_output_background_with_success_colorless():
         pass
 
     filename = bg_feature_name('simple')
-    runner = Runner(filename, verbosity=4)
+    runner = Runner(filename, verbosity=3, use_color=False)
 
     runner.run()
 
@@ -1286,7 +1286,7 @@ def test_output_background_with_success_colorless():
 
 @with_setup(prepare_stdout)
 def test_output_background_with_success_colorful():
-    "A feature with background should print it accordingly under verbosity 3"
+    "A feature with background should print it accordingly under verbosity 3 and colored output"
 
     from lettuce import step
 
@@ -1297,7 +1297,7 @@ def test_output_background_with_success_colorful():
         pass
 
     filename = bg_feature_name('simple')
-    runner = Runner(filename, verbosity=3)
+    runner = Runner(filename, verbosity=3, use_color=True)
 
     runner.run()
 
@@ -1410,7 +1410,7 @@ def test_feature_missing_scenarios():
 def test_output_with_undefined_steps_colorful():
     "With colored output, an undefined step should be printed in sequence."
 
-    runner = Runner(feature_name('undefined_steps'), verbosity=3)
+    runner = Runner(feature_name('undefined_steps'), verbosity=3, use_color=True)
     runner.run()
 
     assert_stdout_lines_with_traceback(

--- a/tests/integration/test_alfaces.py
+++ b/tests/integration/test_alfaces.py
@@ -29,7 +29,7 @@ def test_django_agains_alfaces():
     'running the "harvest" django command with verbosity 3'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3")
+        "python manage.py harvest --verbosity=3 --no-color")
     assert_equals(status, 0, out)
 
     assert "Test the django app DO NOTHING" in out
@@ -67,7 +67,7 @@ def test_django_background_server_running_in_background():
 
     try:
         status, out = commands.getstatusoutput(
-            "python manage.py harvest --verbosity=3")
+            "python manage.py harvest --verbosity=3 --no-color")
         assert_equals(out, e)
         assert_not_equals(status, 0)
 
@@ -106,7 +106,7 @@ def test_django_background_server_running_in_background_with_custom_port():
 
     try:
         status, out = commands.getstatusoutput(
-            "python manage.py harvest --verbosity=3 --port=9889")
+            "python manage.py harvest --verbosity=3 --no-color --port=9889")
         assert_equals(out, e)
         assert_not_equals(status, 0)
 
@@ -119,7 +119,7 @@ def test_limit_by_app_getting_all_apps_by_comma():
     'running "harvest" with --apps=multiple,apps,separated,by,comma'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3 --apps=foobar,donothing")
+        "python manage.py harvest --verbosity=3 --no-color --apps=foobar,donothing")
     assert_equals(status, 0, out)
 
     assert "Test the django app DO NOTHING" in out
@@ -131,7 +131,7 @@ def test_limit_by_app_getting_one_app():
     'running "harvest" with --apps=one_app'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3 --apps=foobar")
+        "python manage.py harvest --verbosity=3 --no-color --apps=foobar")
     assert_equals(status, 0, out)
 
     assert "Test the django app DO NOTHING" not in out
@@ -143,7 +143,7 @@ def test_excluding_apps_separated_by_comma():
     'running "harvest" with --avoid-apps=multiple,apps'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3 --avoid-apps=donothing,foobar")
+        "python manage.py harvest --verbosity=3 --no-color --avoid-apps=donothing,foobar")
     assert_equals(status, 0, out)
 
     assert "Test the django app DO NOTHING" not in out
@@ -155,7 +155,7 @@ def test_excluding_app():
     'running "harvest" with --avoid-apps=one_app'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3 --avoid-apps=donothing")
+        "python manage.py harvest --verbosity=3 --no-color --avoid-apps=donothing")
     assert_equals(status, 0, out)
 
     assert "Test the django app DO NOTHING" not in out
@@ -168,7 +168,7 @@ def test_running_only_apps_within_lettuce_apps_setting():
              'setting LETTUCE_APPS is set'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --settings=onlyfoobarsettings --verbosity=3")
+        "python manage.py harvest --settings=onlyfoobarsettings --verbosity=3 --no-color")
     assert_equals(status, 0, out)
 
     assert "Test the django app FOO BAR" in out
@@ -182,7 +182,7 @@ def test_running_all_apps_but_lettuce_avoid_apps():
 
     status, out = commands.getstatusoutput(
         "python manage.py harvest --settings=allbutfoobarsettings " \
-        "--verbosity=3")
+        "--verbosity=3 --no-color")
 
     assert_equals(status, 0, out)
 
@@ -197,7 +197,7 @@ def test_ignores_settings_avoid_apps_if_apps_argument_is_passed():
 
     status, out = commands.getstatusoutput(
         "python manage.py harvest --settings=avoidallappssettings "
-        "--verbosity=3 --apps=foobar,donothing")
+        "--verbosity=3 --no-color --apps=foobar,donothing")
     assert_equals(status, 0, out)
 
     assert "Test the django app FOO BAR" in out
@@ -209,7 +209,7 @@ def test_no_server():
     '"harvest" --no-server does not start the server'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3 --apps=foobar --no-server")
+        "python manage.py harvest --verbosity=3 --no-color --apps=foobar --no-server")
 
     assert_equals(status, 0, out)
     assert "Django's builtin server is running at" not in out
@@ -221,7 +221,7 @@ def test_django_specifying_scenarios_to_run():
             '--scenarios or -s options'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3 --scenarios=2,5 -a foobar")
+        "python manage.py harvest --verbosity=3 --no-color --scenarios=2,5 -a foobar")
     assert_equals(status, 0, out)
 
     assert "2nd scenario" in out
@@ -239,7 +239,7 @@ def test_django_specifying_scenarios_to_run_by_tag():
             '--tags or -t options'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3 --tag=fast -a foobar")
+        "python manage.py harvest --verbosity=3 --no-color --tag=fast -a foobar")
     assert_equals(status, 0, out)
 
     assert "3rd scenario" in out
@@ -256,7 +256,7 @@ def test_running_only_specified_features():
     'it can run only the specified features, passing the file path'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3 " \
+        "python manage.py harvest --verbosity=3 --no-color " \
         "foobar/features/foobar.feature")
 
     assert_equals(status, 0, out)
@@ -270,7 +270,7 @@ def test_specifying_features_in_inner_directory():
     'it can run only the specified features from a subdirectory'
 
     status, out = commands.getstatusoutput(
-        "python manage.py harvest --verbosity=3 " \
+        "python manage.py harvest --verbosity=3 --no-color " \
         "foobar/features/deeper/deeper/leaf.feature")
 
     assert_equals(status, 0, out)


### PR DESCRIPTION
Fixes the issue #480 - complements the @hmleal implementation:

 * Adds the **--no-color** option when the django is lesser than 1.7 or when running outside django;
 * Accepts verbosity=4 but warns it is deprecated in favor of verbosity=3 without --no-color option;
 * Use the --no-color to define the colored output;

There are missing points:

 * Anyone using verbosity=3 should pass --no-color, otherwise, would get colored output. This approach break in use code. I can make --no-color defaults to True during a transition period, what do you think about?
 * I updated some tests, following @hmleal initial adjustment, but there are another breaking functionalities. For instance, the manage.py approach call the execute_manager, unavailable in newer django versions. If the core team approves my and @hmleal approach, we can try to update the tests for newer django versions.

Let me know if I missed anything.