### PR TITLE
Avoid deprecation warning about django's importlib and prepare to django 1.9.

### DIFF
--- a/lettuce/django/apps.py
+++ b/lettuce/django/apps.py
@@ -16,7 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from os.path import join, dirname
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 from django.conf import settings
 
 


### PR DESCRIPTION
Django 1.9 doesn't provide the [importlib module anymore](https://docs.djangoproject.com/en/1.8/releases/1.7/#django-utils-dictconfig-django-utils-importlib), deprecated since django 1.7. We must rely on python 2.7+ importlib itself, from where the django implementation of importlib were copied.

I fix it trying to import from python itself and, in case of fail, import from django. This would keep backward compatibilities if anyone is using older django versions with python 2.6.

Note that django 1.7+ [only support python 2.7](https://docs.djangoproject.com/en/1.7/faq/install/#what-python-version-can-i-use-with-django).