### PR TITLE
Fixes #476, change the syntax of caught exceptions.

### DIFF
--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -177,7 +177,7 @@ class Runner(object):
                                 random=self.random,
                                 failfast=self.failfast))
 
-        except exceptions.LettuceSyntaxError, e:
+        except exceptions.LettuceSyntaxError as e:
             sys.stderr.write(e.msg)
             failed = True
         except:

--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -71,7 +71,7 @@ __all__ = [
 try:
     terrain = fs.FileSystem._import("terrain")
     reload(terrain)
-except Exception, e:
+except Exception as e:
     if not "No module named terrain" in str(e):
         string = 'Lettuce has tried to load the conventional environment ' \
             'module "terrain"\nbut it has errors, check its contents and ' \
@@ -161,7 +161,7 @@ class Runner(object):
         # that we don't even want to test.
         try:
             self.loader.find_and_load_step_definitions()
-        except StepLoadingError, e:
+        except StepLoadingError as e:
             print "Error loading step definitions:\n", e
             return
 

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -143,7 +143,7 @@ class StepDefinition(object):
         try:
             ret = self.function(self.step, *args, **kw)
             self.step.passed = True
-        except Exception, e:
+        except Exception as e:
             self.step.failed = True
             self.step.why = ReasonToFail(self.step, e)
             raise
@@ -479,10 +479,10 @@ class Step(object):
                     step.run(ignore_case)
                     steps_passed.append(step)
 
-            except NoDefinitionFound, e:
+            except NoDefinitionFound as e:
                 steps_undefined.append(e.step)
 
-            except Exception, e:
+            except Exception as e:
                 steps_failed.append(step)
                 reasons_to_fail.append(step.why)
                 if failfast:
@@ -885,7 +885,7 @@ class Background(object):
             call_hook('before_each', 'step', step)
             try:
                 results.append(step.run(ignore_case))
-            except Exception, e:
+            except Exception as e:
                 print e
                 pass
 

--- a/lettuce/django/management/commands/harvest.py
+++ b/lettuce/django/management/commands/harvest.py
@@ -162,7 +162,7 @@ class Command(BaseCommand):
         if run_server:
             try:
                 server.start()
-            except LettuceServerException, e:
+            except LettuceServerException as e:
                 raise SystemExit(e)
 
         os.environ['SERVER_NAME'] = str(server.address)
@@ -196,10 +196,10 @@ class Command(BaseCommand):
                 results.append(result)
                 if not result or result.steps != result.steps_passed:
                     failed = True
-        except SystemExit, e:
+        except SystemExit as e:
             failed = e.code
 
-        except Exception, e:
+        except Exception as e:
             failed = True
             import traceback
             traceback.print_exc(e)

--- a/lettuce/fs.py
+++ b/lettuce/fs.py
@@ -48,7 +48,7 @@ class FeatureLoader(object):
             to_load = FileSystem.filename(filename, with_extension=False)
             try:
                 module = __import__(to_load)
-            except ValueError, e:
+            except ValueError as e:
                 import traceback
                 err_msg = traceback.format_exc(e)
                 if 'empty module name' in err_msg.lower():
@@ -144,7 +144,7 @@ class FileSystem(object):
         """
         try:
             os.makedirs(path)
-        except OSError, e:
+        except OSError as e:
             # ignore if path already exists
             if e.errno not in (17, ):
                 raise e

--- a/lettuce/registry.py
+++ b/lettuce/registry.py
@@ -69,7 +69,7 @@ class StepDict(dict):
     def _assert_is_step(self, step, func):
         try:
             re.compile(step)
-        except re.error, e:
+        except re.error as e:
             raise StepLoadingError("Error when trying to compile:\n"
                                    "  regex: %r\n"
                                    "  for function: %s\n"

--- a/lettuce/registry.py
+++ b/lettuce/registry.py
@@ -133,7 +133,7 @@ def call_hook(situation, kind, *args, **kw):
     for callback in CALLBACK_REGISTRY[kind][situation]:
         try:
             callback(*args, **kw)
-        except Exception, e:
+        except Exception as e:
             print "=" * 1000
             traceback.print_exc(e)
             print

--- a/tests/integration/django/chive/features/step_definitions/steps.py
+++ b/tests/integration/django/chive/features/step_definitions/steps.py
@@ -12,7 +12,7 @@ def get_url(url):
 
     try:
         world.last_response = urllib2.urlopen(url)
-    except Exception, e:
+    except Exception as e:
         world.last_response = e
 
     return world.last_response

--- a/tests/integration/django/grocery/features/step_definitions/grocery_steps.py
+++ b/tests/integration/django/grocery/features/step_definitions/grocery_steps.py
@@ -14,7 +14,7 @@ def get_url(url):
 
     try:
         world.last_response = urllib2.urlopen(url)
-    except Exception, e:
+    except Exception as e:
         world.last_response = e
 
     return world.last_response

--- a/tests/unit/test_step_parsing.py
+++ b/tests/unit/test_step_parsing.py
@@ -226,7 +226,7 @@ def test_hashes__first_attr_raises_assertion_error_if_empty():
     try:
         step.hashes.first
         failed = False
-    except AssertionError, e:
+    except AssertionError as e:
         failed = True
         assert_equals(
             unicode(e),
@@ -253,7 +253,7 @@ def test_hashes__last_attr_raises_assertion_error_if_empty():
     try:
         step.hashes.last
         failed = False
-    except AssertionError, e:
+    except AssertionError as e:
         failed = True
         assert_equals(
             unicode(e),
@@ -276,7 +276,7 @@ def test_handy_function_for_table_members_fail_giving_assertionerror():
     try:
         step.hashes.values_under('Foobar')
         failed = False
-    except AssertionError, e:
+    except AssertionError as e:
         failed = True
         assert_equals(
             unicode(e),


### PR DESCRIPTION
Python 3 [resolves an ambiguity in catching exception syntax](https://www.python.org/dev/peps/pep-3110/). There is no longer support for **Except, e**. We must rely on **Except as e**.

I changed every occurrence of that in the lettuce base code and this fixes the #476 issue.

I can't guarantee the tests passes in python 3.4, but I can update travis.yml to test over python 3.4 too. What do you think about it?