### PR TITLE
Remove deprecated --use-mirrors option from pip install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ envlist = py26, py27
 
 [testenv]
 commands =
-    pip install --use-mirrors -q -r requirements.txt
+    pip install -q -r requirements.txt
     make unit functional


### PR DESCRIPTION
This option was removed in pip version 7.0.0. See: https://pip.pypa.io/en/stable/news.html