### PR TITLE
added compiled regexes

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -357,9 +357,9 @@ class Step(object):
 
     def _get_match(self, ignore_case):
         matched, func = None, lambda: None
-
-        for regex, func in STEP_REGISTRY.items():
-            matched = re.search(regex, self.sentence, ignore_case and re.I or 0)
+        for step, func in STEP_REGISTRY.items():
+            regex = STEP_REGISTRY.get_regex(step, ignore_case)
+            matched = regex.search(self.sentence)
             if matched:
                 break
 
@@ -1354,4 +1354,3 @@ class SummaryTotalResults(TotalResult):
                     self._proposed_definitions.extend(scenario_result.steps_undefined)
                     if len(scenario_result.steps_failed) > 0:
                         self.failed_scenario_locations.append(scenario_result.scenario.represented())
-

--- a/lettuce/registry.py
+++ b/lettuce/registry.py
@@ -41,6 +41,24 @@ class CallbackDict(dict):
                 callback_list[:] = []
 
 class StepDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(StepDict, self).__init__(*args, **kwargs)
+        self._compiled = {}
+        self._compiled_ignore_case = {}
+
+    def get_regex(self, step, ignore_case=False):
+        if ignore_case:
+            regex = self._compiled_ignore_case.get(step, None)
+            if not regex:
+                regex = re.compile(step, re.I)
+                self._compiled_ignore_case[step] = regex
+        else:
+            regex = self._compiled.get(step, None)
+            if not regex:
+                regex = re.compile(step)
+                self._compiled[step] = regex
+        return regex
+
     def load(self, step, func):
         self._assert_is_step(step, func)
         self[step] = func


### PR DESCRIPTION
Tests have been running very slowly for me. I profiled the code and noticed that lettuce was spending most of its time compiling regexes in _get_match. I've modified the code to re-use compiled regexes stored in the STEP_REGISTRY, and it solved my performance problem. 
