### PR TITLE
Use migrate command for Django versions greater than 1.7

### DIFF
--- a/lettuce/django/management/commands/harvest.py
+++ b/lettuce/django/management/commands/harvest.py
@@ -172,9 +172,12 @@ class Command(BaseCommand):
             self._testrunner.setup_test_environment()
             self._old_db_config = self._testrunner.setup_databases()
 
-            call_command('syncdb', verbosity=0, interactive=False,)
-            if migrate_south:
-               call_command('migrate', verbosity=0, interactive=False,)
+            if StrictVersion(django.get_version()) < StrictVersion('1.7'):
+                call_command('syncdb', verbosity=0, interactive=False,)
+                if migrate_south:
+                   call_command('migrate', verbosity=0, interactive=False,)
+            else:
+                call_command('migrate', verbosity=0, interactive=False,)
 
         settings.DEBUG = options.get('debug', False)
 


### PR DESCRIPTION
When you run harvest -T to use the test database,  It's trying to use syncdb which is deprecated since django 1.7.

This PR uses Django migrate when It's greater than 1.7