### PR TITLE
before.each_outline / after.each_outlne hook created. Closes #451 (gabrielfalcao/lettuce/issues/451)

### DIFF
--- a/docs/reference/terrain.rst
+++ b/docs/reference/terrain.rst
@@ -320,6 +320,44 @@ by the fact that its ran *after* lettuce run the scenario.
    def teardown_some_scenario(scenario):
        models.reset_all_data()
 
+@before.each_outline
+====================
+
+This hook is ran before lettuce run each scenario outline iteration
+
+The decorated function takes a :ref:`scenario-class` as parameter and
+outline dict where each column name is key
+
+
+.. highlight:: python
+
+.. doctest::
+
+   from lettuce import *
+
+   @before.each_outline
+   def setup_some_scenario(scenario, outline):
+       print "We are now going to run scenario {0} with size={1}".format(scenario.name, outline["size"])
+
+
+@after.each_outline
+===================
+
+This hooks behaves in the same way @before.each_outline does, except
+by the fact that its ran *after* lettuce run the scenario outline iteration.
+
+
+.. highlight:: python
+
+.. doctest::
+
+   from lettuce import *
+
+   @after.each_outline
+   def complete_some_scenario(scenario, outline):
+       print "We are now finished scenario {0} with size={1}".format(scenario.name, outline["size"])
+
+
 @before.each_step
 =================
 

--- a/lettuce/registry.py
+++ b/lettuce/registry.py
@@ -119,6 +119,10 @@ CALLBACK_REGISTRY = CallbackDict(
             'after_each': [],
             'outline': [],
         },
+        'outline': {
+            'before_each': [],
+            'after_each': [],
+        },
         'background': {
             'before_each': [],
             'after_each': [],

--- a/lettuce/terrain.py
+++ b/lettuce/terrain.py
@@ -55,6 +55,7 @@ for name, where, when in (
         ('each_step', 'step', '%(0)s_each'),
         ('step_output', 'step',  '%(0)s_output'),
         ('each_scenario', 'scenario', '%(0)s_each'),
+        ('each_outline', 'outline', '%(0)s_each'),
         ('each_background', 'background', '%(0)s_each'),
         ('each_feature', 'feature', '%(0)s_each'),
         ('harvest', 'harvest', '%(0)s'),


### PR DESCRIPTION
New hook for outline added. It works before_each outline and after_each outline. It is required for PyCharm lettuce scenario outline support, and it is useful anyway.

Old hook is left unchanged to keep old API, but it can't be used because it is not called before and after each outline, and in case of exception and fastfail it is called after after_scenario.