### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ all them are used within lettuce tests
     > mkvirtualenv lettuce
     > workon lettuce
     > pip install -r requirements.txt
-note this uses [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/) to save some virtualenv handling hassle. you can also use virtualenv the regular way.
+note this uses [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) to save some virtualenv handling hassle. you can also use virtualenv the regular way.
 ## or just install manually:
 
     > sudo pip install -r requirements.txt


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.