### PR TITLE
Fix harvest error with requires_model_validation

### DIFF
--- a/lettuce/django/management/commands/harvest.py
+++ b/lettuce/django/management/commands/harvest.py
@@ -38,7 +38,7 @@ from lettuce.django.server import LettuceServerException
 class Command(BaseCommand):
     help = u'Run lettuce tests all along installed apps'
     args = '[PATH to feature file or folder]'
-    requires_model_validation = requires_system_checks = False
+    requires_system_checks = False
 
     option_list = BaseCommand.option_list + (
         make_option('-a', '--apps', action='store', dest='apps', default='',


### PR DESCRIPTION
Addresses this error I ran into with the new 0.2.23 release, introduced in the django 1.9 changes https://github.com/gabrielfalcao/lettuce/pull/522:

>  File
>  "/home/travis/build/ccnmtl/mediathread/ve/lib/python2.7/site-packages/django/core/management/base.py",
>  line 265, in **init**
> 
> ```
>  '"requires_system_checks".' % self.__class__.__name__)
> ```
> 
> django.core.exceptions.ImproperlyConfigured: Command Command defines
> both "requires_model_validation" and "requires_system_checks", which is
> illegal. Use only "requires_system_checks".
> make: **\* [harvest1] Error 1
