### PR TITLE
added root_dir to set where the runner looks for steps to import

### DIFF
--- a/lettuce/django/management/commands/harvest.py
+++ b/lettuce/django/management/commands/harvest.py
@@ -227,6 +227,7 @@ class Command(BaseCommand):
                                 subunit_filename=options.get('subunit_file'),
                                 jsonreport_filename=options.get('jsonreport_file'),
                                 tags=tags, failfast=failfast, auto_pdb=auto_pdb,
+                                root_dir=path,
                                 smtp_queue=smtp_queue)
 
                 result = runner.run()


### PR DESCRIPTION
in djnago 1.9 this causes the models.py file to attempt import causing an error like:

RuntimeError: Model class models.<Your model> doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.