### PR TITLE
Fix spacing in example

### DIFF
--- a/docs/tutorial/simple.rst
+++ b/docs/tutorial/simple.rst
@@ -475,7 +475,7 @@ Steps can be grouped in class decorated with "@steps"
           assert number == expected, msg % number
 
       def have_the_number(self, step, number):
-        '''I have the number (\d+)'''
+          '''I have the number (\d+)'''
           self.set_number(number)
 
       def i_compute_its_factorial(self, step):


### PR DESCRIPTION
Users generally rely on the fact that they should be able to copy-paste the example and expect it to run :-)
