### PR TITLE
Add --keepdb parameter passing to Django test runner 

### DIFF
--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -95,13 +95,14 @@ class Runner(object):
                  enable_subunit=False, subunit_filename=None,
                  enable_jsonreport=False, jsonreport_filename=None,
                  tags=None, failfast=False, auto_pdb=False,
-                 smtp_queue=None, root_dir=None):
+                 smtp_queue=None, root_dir=None, keepdb=False):
 
         """ lettuce.Runner will try to find a terrain.py file and
         import it from within `base_path`
         """
 
         self.tags = tags
+        self.keepdb = keepdb
         self.single_feature = None
 
         if os.path.isfile(base_path) and os.path.exists(base_path):

--- a/lettuce/django/management/commands/harvest.py
+++ b/lettuce/django/management/commands/harvest.py
@@ -124,6 +124,10 @@ class Command(BaseCommand):
             "--pdb", dest="auto_pdb", default=False, action="store_true",
             help='Launches an interactive debugger upon error'
         )
+        parser.add_argument(
+            '-k', '--keepdb', action='store_true', dest='keepdb', default=False,
+            help='Preserves the test DB between runs.'
+        )
         if DJANGO_VERSION < StrictVersion('1.7'):
             # Django 1.7 introduces the --no-color flag. We must add the flag
             # to be compatible with older django versions
@@ -159,6 +163,7 @@ class Command(BaseCommand):
         failfast = options['failfast']
         auto_pdb = options['auto_pdb']
         threading = options['use_threading']
+        keepdb = options['keepdb']
 
         if test_database:
             migrate_south = getattr(settings, "SOUTH_TESTS_MIGRATE", True)
@@ -170,7 +175,7 @@ class Command(BaseCommand):
                 pass
 
             from django.test.utils import get_runner
-            self._testrunner = get_runner(settings)(interactive=False)
+            self._testrunner = get_runner(settings)(interactive=False, keepdb=keepdb, verbosity=verbosity)              # debug_sql=False, parallel=0
             self._testrunner.setup_test_environment()
             self._old_db_config = self._testrunner.setup_databases()
 
@@ -217,7 +222,7 @@ class Command(BaseCommand):
                                 subunit_filename=options.get('subunit_file'),
                                 jsonreport_filename=options.get('jsonreport_file'),
                                 tags=tags, failfast=failfast, auto_pdb=auto_pdb,
-                                smtp_queue=smtp_queue)
+                                smtp_queue=smtp_queue, keepdb=keepdb)
 
                 result = runner.run()
                 if app_module is not None:


### PR DESCRIPTION
In our use case, we use Lettuce together with Django test runner's test database functions. We would like to re-use the test database between test runs, because it simply takes too much time to re-create it every time with running the migrations the tests are launched. Also in our CI server, we initialize the test database before calling Lettuce from a previously exported database dump file to speed up the run.

We have added the `--keepdb` parameter to prevent Lettuce from dropping the test database on each test run when used together with the `--test-server` parameter. The `--keepdb` parameter value is passed on directly to Django's own test runner which handles it accordingly.



