### PR TITLE
honor --no-color flag

### DIFF
--- a/lettuce/bin.py
+++ b/lettuce/bin.py
@@ -120,6 +120,7 @@ def main(args=sys.argv[1:]):
         base_path,
         scenarios=options.scenarios,
         verbosity=options.verbosity,
+        no_color=options.no_color,
         random=options.random,
         enable_xunit=options.enable_xunit,
         xunit_filename=options.xunit_file,


### PR DESCRIPTION
The --no-color flag was being accepted, but its value was not being passed to the Runner. As a result, without this change it was not possible to disable colored output if running at verbosity=3.