### PR TITLE
Fix tags matcher not working with exclusionary_tags

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -655,8 +655,10 @@ class Scenario(object):
         matched = []
 
         if isinstance(self.tags, list):
+            positive_tags = [tag for tag in tags if not tag.startswith('-') and not tag.startswith('~')]
+
             for tag in self.tags:
-                if tag in tags:
+                if tag in positive_tags:
                     return True
         else:
             self.tags = []

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -683,7 +683,7 @@ class Scenario(object):
             elif tag in self.tags:
                 matched.append(True)
 
-        return all(matched)
+        return matched and all(matched)
 
     @property
     def evaluated(self):

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -679,7 +679,8 @@ class Scenario(object):
                 matched.append(result)
             elif exclude:
                 result = tag not in self.tags
-                matched.append(result)
+                # any exclude tag means reject test
+                return False
             elif tag in self.tags:
                 matched.append(True)
 

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -654,12 +654,7 @@ class Scenario(object):
 
         matched = []
 
-        if isinstance(self.tags, list) and not has_exclusionary_tags:
-
-            for tag in self.tags:
-                if tag in tags:
-                    return True
-        else:
+        if not isinstance(self.tags, list):
             self.tags = []
 
         for tag in tags:

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -654,11 +654,10 @@ class Scenario(object):
 
         matched = []
 
-        if isinstance(self.tags, list):
-            positive_tags = [tag for tag in tags if not tag.startswith('-') and not tag.startswith('~')]
+        if isinstance(self.tags, list) and not has_exclusionary_tags:
 
             for tag in self.tags:
-                if tag in positive_tags:
+                if tag in tags:
                     return True
         else:
             self.tags = []

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -658,6 +658,7 @@ class Scenario(object):
             self.tags = []
 
         for tag in tags:
+            result = True
             exclude = tag.startswith('-')
             if exclude:
                 tag = tag[1:]
@@ -682,7 +683,9 @@ class Scenario(object):
                 # any exclude tag means reject test
                 return False
             elif tag in self.tags:
-                matched.append(True)
+                result = True
+
+            matched.append(result)
 
         return matched and all(matched)
 

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -666,7 +666,6 @@ class Scenario(object):
             if fuzzable:
                 tag = tag[1:]
 
-            result = tag in self.tags
             if fuzzable:
                 fuzzed = []
                 for internal_tag in self.tags:
@@ -677,10 +676,12 @@ class Scenario(object):
                         fuzzed.append(ratio > 80)
 
                 result = any(fuzzed)
+                matched.append(result)
             elif exclude:
                 result = tag not in self.tags
-
-            matched.append(result)
+                matched.append(result)
+            elif tag in self.tags:
+                matched.append(True)
 
         return all(matched)
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if os.name.lower() == 'nt':
 
 setup(
     name='lettuce',
-    version='0.2.23',
+    version='0.2.24',
     description='Behaviour Driven Development for python',
     author='Gabriel Falcao',
     author_email='gabriel@nacaolivre.org',


### PR DESCRIPTION
Lettuce is actually ignoring negative cases in case of a job has more than one tag.
It is basically directly doing a return True in case of a positive, and ignoring all the exclusionary ones.

This simple line fixes it.

How to reproduce issue:
```
self.tags is
[u'guest', u'behave']
```
and tags is: 
```
['-behave', 'guest']
```
What will happen right now is that lettuce will match guest and will run the scenario, but it will ignore the -behave that should have removed that scenario.
