### PR TITLE
WIP: Rely on tox to run tests and test supported django versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: python
 python:
   - "2.7"
-# command to install dependencies
 install:
-  - pip install -r requirements.txt
-  # Deal with issue on Travis builders re: multiprocessing.Queue :(
-  - "sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm"
-# command to run tests
-script: make unit functional
+  - pip install tox
+script: tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Django==1.9.4
 Jinja2==2.8
 Pygments==1.5
 Sphinx==1.1.3

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,14 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27
+envlist = py27-django{18,110,111}
 
 [testenv]
+deps =
+    -r{toxinidir}/requirements.txt
+    django18: Django>=1.8,<1.9
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2
 commands =
-    pip install -q -r requirements.txt
     make unit functional
 whitelist_externals = make


### PR DESCRIPTION
Use tox instead travis directly to let someone to run tests in the same
way travis would do.