### PR TITLE
Properly set step.failed/passed in StepDefinition

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -143,8 +143,10 @@ class StepDefinition(object):
         try:
             ret = self.function(self.step, *args, **kw)
             self.step.passed = True
+            self.step.failed = False
         except Exception as e:
             self.step.failed = True
+            self.step.passed = False
             self.step.why = ReasonToFail(self.step, e)
             raise
 


### PR DESCRIPTION
In some corner cases, step.failed and step.passed can
simultaneously be true. This is obviously an error.

This commit forces step.passed to False in case of failure
and step.failed to False in case of success.

I assume the conditions for the corner case revolve around
outline support, where a step is cloned and may possibly
inherit the passed flag from a previous run. But that's
just conjecture, I did not trace this completely.

Finally, step.behave_as always sets both step.failed and step.passed,
so StepDefinition probably should do the same.

I am currently unable to install all dependencies for testing, but I assume there is a CI setup for this repository.