### PR TITLE
Use tags as suite name in xml report.

### DIFF
--- a/lettuce/__init__.py
+++ b/lettuce/__init__.py
@@ -133,7 +133,7 @@ class Runner(object):
         self.random = random
 
         if enable_xunit:
-            xunit_output.enable(filename=xunit_filename)
+            xunit_output.enable(filename=xunit_filename, tags=tags)
         if smtp_queue:
             smtp_mail_queue.enable()
 

--- a/lettuce/plugins/xunit_output.py
+++ b/lettuce/plugins/xunit_output.py
@@ -39,11 +39,14 @@ def total_seconds(td):
     return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 1e6) / 1e6
 
 
-def enable(filename=None):
+def enable(filename=None, tags=None):
 
     doc = minidom.Document()
     root = doc.createElement("testsuite")
-    root.setAttribute("name", "lettuce")
+    if tags:
+        root.setAttribute("name", "_".join(tags))
+    else:    
+        root.setAttribute("name", "lettuce")
     root.setAttribute("hostname", "localhost")
     root.setAttribute("timestamp", datetime.now().strftime("%Y-%m-%dT%H:%M:%S"))
     output_filename = filename or "lettucetests.xml"


### PR DESCRIPTION
Hi, 

We're using Jenkins2 pipelines in our project.
Pipeline allows us to execute several tests suites in parallel.

Problem is that junit plugin can attach only one test report because all produced xml files has the same name attribute.
