### PR TITLE
docs: fix simple typo, repcipes -> recipes

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -8,7 +8,7 @@ Here are guidelines to get a development environment for lettuce.
 OS specific
 ***********
 
-Here are repcipes for specific operating systems. They should help you go fast
+Here are recipes for specific operating systems. They should help you go fast
 or automate lettuce installation procedure:
 
 .. toctree::

--- a/specs/dev/install.md
+++ b/specs/dev/install.md
@@ -6,7 +6,7 @@ Here are guidelines to get a development environment for lettuce.
 OS specific
 -----------
 
-Here are repcipes for specific operating systems. They should help you
+Here are recipes for specific operating systems. They should help you
 go fast or automate lettuce installation procedure:
 
 Generic guidelines


### PR DESCRIPTION
There is a small typo in docs/dev/install.rst, specs/dev/install.md.

Should read `recipes` rather than `repcipes`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md